### PR TITLE
Dev

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>dev.neuralnexus.ampapi</groupId>
     <artifactId>ampapi</artifactId>
-    <version>1.2.5</version>
+    <version>1.2.6</version>
 
     <properties>
         <java.version>1.7</java.version>

--- a/src/main/java/dev/neuralnexus/ampapi/apimodules/ADSModule.java
+++ b/src/main/java/dev/neuralnexus/ampapi/apimodules/ADSModule.java
@@ -18,163 +18,147 @@ public class ADSModule extends AMPAPI {
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param newDatastore False
+     * Name Description Optional
+     * @param newDatastore  False
      * @return ActionResult
      */
     public ActionResult AddDatastore(InstanceDatastore newDatastore) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("newDatastore", newDatastore);
-        Type type = new TypeToken<ActionResult>() {}.getType();
+        Type type = new TypeToken<ActionResult>(){}.getType();
         return (ActionResult) this.APICall("ADSModule/AddDatastore", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param InstanceID False
-     * @param Args False
-     * @param RebuildConfiguration True
+     * Name Description Optional
+     * @param InstanceID  False
+     * @param Args  False
+     * @param RebuildConfiguration  True
      * @return Task<ActionResult>
      */
-    public Task<ActionResult> ApplyInstanceConfiguration(
-            UUID InstanceID, Map<String, String> Args, Boolean RebuildConfiguration) {
+    public Task<ActionResult> ApplyInstanceConfiguration(UUID InstanceID, Map<String, String> Args, Boolean RebuildConfiguration) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("InstanceID", InstanceID);
         args.put("Args", Args);
         args.put("RebuildConfiguration", RebuildConfiguration);
-        Type type = new TypeToken<Task<ActionResult>>() {}.getType();
-        return (Task<ActionResult>)
-                this.APICall("ADSModule/ApplyInstanceConfiguration", args, type);
+        Type type = new TypeToken<Task<ActionResult>>(){}.getType();
+        return (Task<ActionResult>) this.APICall("ADSModule/ApplyInstanceConfiguration", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param InstanceID False
-     * @param TemplateID False
-     * @param NewFriendlyName True
-     * @param Secret True
-     * @param RestartIfPreviouslyRunning True
+     * Name Description Optional
+     * @param InstanceID  False
+     * @param TemplateID  False
+     * @param NewFriendlyName  True
+     * @param Secret  True
+     * @param RestartIfPreviouslyRunning  True
      * @return ActionResult
      */
-    public ActionResult ApplyTemplate(
-            UUID InstanceID,
-            Integer TemplateID,
-            String NewFriendlyName,
-            String Secret,
-            Boolean RestartIfPreviouslyRunning) {
+    public ActionResult ApplyTemplate(UUID InstanceID, Integer TemplateID, String NewFriendlyName, String Secret, Boolean RestartIfPreviouslyRunning) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("InstanceID", InstanceID);
         args.put("TemplateID", TemplateID);
         args.put("NewFriendlyName", NewFriendlyName);
         args.put("Secret", Secret);
         args.put("RestartIfPreviouslyRunning", RestartIfPreviouslyRunning);
-        Type type = new TypeToken<ActionResult>() {}.getType();
+        Type type = new TypeToken<ActionResult>(){}.getType();
         return (ActionResult) this.APICall("ADSModule/ApplyTemplate", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param Friendly False
-     * @param IsHTTPS False
-     * @param Host False
-     * @param Port False
-     * @param InstanceID False
+     * Name Description Optional
+     * @param Friendly  False
+     * @param IsHTTPS  False
+     * @param Host  False
+     * @param Port  False
+     * @param InstanceID  False
      * @return ActionResult
      */
-    public ActionResult AttachADS(
-            String Friendly, Boolean IsHTTPS, String Host, Integer Port, UUID InstanceID) {
+    public ActionResult AttachADS(String Friendly, Boolean IsHTTPS, String Host, Integer Port, UUID InstanceID) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("Friendly", Friendly);
         args.put("IsHTTPS", IsHTTPS);
         args.put("Host", Host);
         args.put("Port", Port);
         args.put("InstanceID", InstanceID);
-        Type type = new TypeToken<ActionResult>() {}.getType();
+        Type type = new TypeToken<ActionResult>(){}.getType();
         return (ActionResult) this.APICall("ADSModule/AttachADS", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param Id False
-     * @param NewName False
+     * Name Description Optional
+     * @param Id  False
+     * @param NewName  False
      * @return ActionResult
      */
     public ActionResult CloneTemplate(Integer Id, String NewName) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("Id", Id);
         args.put("NewName", NewName);
-        Type type = new TypeToken<ActionResult>() {}.getType();
+        Type type = new TypeToken<ActionResult>(){}.getType();
         return (ActionResult) this.APICall("ADSModule/CloneTemplate", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param InstanceName False
+     * Name Description Optional
+     * @param InstanceName  False
      * @return ActionResult
      */
     public ActionResult ConvertToManaged(String InstanceName) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("InstanceName", InstanceName);
-        Type type = new TypeToken<ActionResult>() {}.getType();
+        Type type = new TypeToken<ActionResult>(){}.getType();
         return (ActionResult) this.APICall("ADSModule/ConvertToManaged", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param Name False
+     * Name Description Optional
+     * @param Name  False
      * @return ActionResult
      */
     public ActionResult CreateDeploymentTemplate(String Name) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("Name", Name);
-        Type type = new TypeToken<ActionResult>() {}.getType();
+        Type type = new TypeToken<ActionResult>(){}.getType();
         return (ActionResult) this.APICall("ADSModule/CreateDeploymentTemplate", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param TargetADSInstance False
-     * @param NewInstanceId False
-     * @param Module False
-     * @param InstanceName False
-     * @param FriendlyName False
-     * @param IPBinding False
-     * @param PortNumber False
-     * @param AdminUsername False
-     * @param AdminPassword False
-     * @param ProvisionSettings False
-     * @param AutoConfigure When enabled, all settings other than the Module, Target and
-     *     FriendlyName are ignored and replaced with automatically generated values. True
-     * @param PostCreate True
-     * @param StartOnBoot True
-     * @param DisplayImageSource True
-     * @param TargetDatastore True
+     * Name Description Optional
+     * @param TargetADSInstance  False
+     * @param NewInstanceId  False
+     * @param Module  False
+     * @param InstanceName  False
+     * @param FriendlyName  False
+     * @param IPBinding  False
+     * @param PortNumber  False
+     * @param AdminUsername  False
+     * @param AdminPassword  False
+     * @param ProvisionSettings  False
+     * @param AutoConfigure When enabled, all settings other than the Module, Target and FriendlyName are ignored and replaced with automatically generated values. True
+     * @param PostCreate  True
+     * @param StartOnBoot  True
+     * @param DisplayImageSource  True
+     * @param TargetDatastore  True
      * @return ActionResult
      */
-    public ActionResult CreateInstance(
-            UUID TargetADSInstance,
-            UUID NewInstanceId,
-            String Module,
-            String InstanceName,
-            String FriendlyName,
-            String IPBinding,
-            Integer PortNumber,
-            String AdminUsername,
-            String AdminPassword,
-            Map<String, String> ProvisionSettings,
-            Boolean AutoConfigure,
-            Object PostCreate,
-            Boolean StartOnBoot,
-            String DisplayImageSource,
-            Integer TargetDatastore) {
+    public ActionResult CreateInstance(UUID TargetADSInstance, UUID NewInstanceId, String Module, String InstanceName, String FriendlyName, String IPBinding, Integer PortNumber, String AdminUsername, String AdminPassword, Map<String, String> ProvisionSettings, Boolean AutoConfigure, Object PostCreate, Boolean StartOnBoot, String DisplayImageSource, Integer TargetDatastore) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("TargetADSInstance", TargetADSInstance);
         args.put("NewInstanceId", NewInstanceId);
@@ -191,121 +175,99 @@ public class ADSModule extends AMPAPI {
         args.put("StartOnBoot", StartOnBoot);
         args.put("DisplayImageSource", DisplayImageSource);
         args.put("TargetDatastore", TargetDatastore);
-        Type type = new TypeToken<ActionResult>() {}.getType();
+        Type type = new TypeToken<ActionResult>(){}.getType();
         return (ActionResult) this.APICall("ADSModule/CreateInstance", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param Instance False
-     * @param PostCreate True
+     * Name Description Optional
+     * @param Instance  False
+     * @param PostCreate  True
      * @return ActionResult
      */
     public ActionResult CreateLocalInstance(Object Instance, Object PostCreate) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("Instance", Instance);
         args.put("PostCreate", PostCreate);
-        Type type = new TypeToken<ActionResult>() {}.getType();
+        Type type = new TypeToken<ActionResult>(){}.getType();
         return (ActionResult) this.APICall("ADSModule/CreateLocalInstance", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param id False
+     * Name Description Optional
+     * @param id  False
      * @return ActionResult
      */
     public ActionResult DeleteDatastore(Integer id) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("id", id);
-        Type type = new TypeToken<ActionResult>() {}.getType();
+        Type type = new TypeToken<ActionResult>(){}.getType();
         return (ActionResult) this.APICall("ADSModule/DeleteDatastore", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param Id False
+     * Name Description Optional
+     * @param Id  False
      * @return ActionResult
      */
     public ActionResult DeleteDeploymentTemplate(Integer Id) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("Id", Id);
-        Type type = new TypeToken<ActionResult>() {}.getType();
+        Type type = new TypeToken<ActionResult>(){}.getType();
         return (ActionResult) this.APICall("ADSModule/DeleteDeploymentTemplate", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param InstanceName False
+     * Name Description Optional
+     * @param InstanceName  False
      * @return Result<RunningTask>
      */
     public Result<RunningTask> DeleteInstance(String InstanceName) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("InstanceName", InstanceName);
-        Type type = new TypeToken<Result<RunningTask>>() {}.getType();
+        Type type = new TypeToken<Result<RunningTask>>(){}.getType();
         return (Result<RunningTask>) this.APICall("ADSModule/DeleteInstance", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param InstanceId False
+     * Name Description Optional
+     * @param InstanceId  False
      * @return Task<ActionResult>
      */
     public Task<ActionResult> DeleteInstanceUsers(UUID InstanceId) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("InstanceId", InstanceId);
-        Type type = new TypeToken<Task<ActionResult>>() {}.getType();
+        Type type = new TypeToken<Task<ActionResult>>(){}.getType();
         return (Task<ActionResult>) this.APICall("ADSModule/DeleteInstanceUsers", args, type);
     }
 
     /**
-     * A dictionary of setting nodes and values to create the new instance with. Identical in
-     * function to the provisioning arguments in the template itself. Name Description Optional
+     * A dictionary of setting nodes and values to create the new instance with. Identical in function to the provisioning arguments in the template itself.
      *
-     * @param TemplateID The ID of the template to be deployed, as per the Template Management UI in
-     *     AMP itself. False
-     * @param NewUsername If specified, AMP will create a new user with this name for this instance.
-     *     Must be unique. If this user already exists, this will be ignored but the new instance
-     *     will be assigned to this user. True
-     * @param NewPassword If 'NewUsername' is specified and the user doesn't already exist, the
-     *     password that will be assigned to this user. True
-     * @param NewEmail If 'NewUsername' is specified and the user doesn't already exist, the email
-     *     address that will be assigned to this user. True
-     * @param RequiredTags If specified, AMP will only deploy this template to targets that have
-     *     every single 'tag' specified in their target configuration. You can adjust this via the
-     *     controller by clicking 'Edit' on the target settings. True
-     * @param Tag Unrelated to RequiredTags. This is to uniquely identify this instance to your own
-     *     systems. It may be something like an order ID or service ID so you can find the
-     *     associated instance again at a later time. If 'UseTagAsInstanceName' is enabled, then
-     *     this will also be used as the instance name for the created instance - but it must be
-     *     unique. True
-     * @param FriendlyName A friendly name for this instance. If left blank, AMP will generate one
-     *     for you. True
-     * @param Secret Must be a non-empty strong in order to get a callback on deployment state
-     *     change. This secret will be passed back to you in the callback so you can verify the
-     *     request. True
-     * @param PostCreate 0: Do nothing, 1: Start instance only, 2: Start instance and update
-     *     application, 3: Full application startup. True
-     * @param ExtraProvisionSettings A dictionary of setting nodes and values to create the new
-     *     instance with. Identical in function to the provisioning arguments in the template
-     *     itself. True
+     * Name Description Optional
+     * @param TemplateID The ID of the template to be deployed, as per the Template Management UI in AMP itself. False
+     * @param NewUsername If specified, AMP will create a new user with this name for this instance. Must be unique. If this user already exists, this will be ignored but the new instance will be assigned to this user. True
+     * @param NewPassword If 'NewUsername' is specified and the user doesn't already exist, the password that will be assigned to this user. True
+     * @param NewEmail If 'NewUsername' is specified and the user doesn't already exist, the email address that will be assigned to this user. True
+     * @param RequiredTags If specified, AMP will only deploy this template to targets that have every single 'tag' specified in their target configuration. You can adjust this via the controller by clicking 'Edit' on the target settings. True
+     * @param Tag Unrelated to RequiredTags. This is to uniquely identify this instance to your own systems. It may be something like an order ID or service ID so you can find the associated instance again at a later time. If 'UseTagAsInstanceName' is enabled, then this will also be used as the instance name for the created instance - but it must be unique. True
+     * @param FriendlyName A friendly name for this instance. If left blank, AMP will generate one for you. True
+     * @param Secret Must be a non-empty strong in order to get a callback on deployment state change. This secret will be passed back to you in the callback so you can verify the request. True
+     * @param PostCreate 0: Do nothing, 1: Start instance only, 2: Start instance and update application, 3: Full application startup. True
+     * @param ExtraProvisionSettings A dictionary of setting nodes and values to create the new instance with. Identical in function to the provisioning arguments in the template itself. True
      * @return Result<RunningTask>
      */
-    public Result<RunningTask> DeployTemplate(
-            Integer TemplateID,
-            String NewUsername,
-            String NewPassword,
-            String NewEmail,
-            List<String> RequiredTags,
-            String Tag,
-            String FriendlyName,
-            String Secret,
-            Object PostCreate,
-            Map<String, String> ExtraProvisionSettings) {
+    public Result<RunningTask> DeployTemplate(Integer TemplateID, String NewUsername, String NewPassword, String NewEmail, List<String> RequiredTags, String Tag, String FriendlyName, String Secret, Object PostCreate, Map<String, String> ExtraProvisionSettings) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("TemplateID", TemplateID);
         args.put("NewUsername", NewUsername);
@@ -317,271 +279,277 @@ public class ADSModule extends AMPAPI {
         args.put("Secret", Secret);
         args.put("PostCreate", PostCreate);
         args.put("ExtraProvisionSettings", ExtraProvisionSettings);
-        Type type = new TypeToken<Result<RunningTask>>() {}.getType();
+        Type type = new TypeToken<Result<RunningTask>>(){}.getType();
         return (Result<RunningTask>) this.APICall("ADSModule/DeployTemplate", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param Id False
+     * Name Description Optional
+     * @param Id  False
      * @return ActionResult
      */
     public ActionResult DetatchTarget(UUID Id) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("Id", Id);
-        Type type = new TypeToken<ActionResult>() {}.getType();
+        Type type = new TypeToken<ActionResult>(){}.getType();
         return (ActionResult) this.APICall("ADSModule/DetatchTarget", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param SourceArchive False
+     * Name Description Optional
+     * @param SourceArchive  False
      * @return Task<ActionResult>
      */
     public Task<ActionResult> ExtractEverywhere(String SourceArchive) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("SourceArchive", SourceArchive);
-        Type type = new TypeToken<Task<ActionResult>>() {}.getType();
+        Type type = new TypeToken<Task<ActionResult>>(){}.getType();
         return (Task<ActionResult>) this.APICall("ADSModule/ExtractEverywhere", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param instanceId False
+     * Name Description Optional
+     * @param instanceId  False
      * @return Result<List<EndpointInfo>>
      */
     public Result<List<EndpointInfo>> GetApplicationEndpoints(UUID instanceId) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("instanceId", instanceId);
-        Type type = new TypeToken<Result<List<EndpointInfo>>>() {}.getType();
-        return (Result<List<EndpointInfo>>)
-                this.APICall("ADSModule/GetApplicationEndpoints", args, type);
+        Type type = new TypeToken<Result<List<EndpointInfo>>>(){}.getType();
+        return (Result<List<EndpointInfo>>) this.APICall("ADSModule/GetApplicationEndpoints", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param id False
+     * Name Description Optional
+     * @param id  False
      * @return InstanceDatastore
      */
     public InstanceDatastore GetDatastore(Integer id) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("id", id);
-        Type type = new TypeToken<InstanceDatastore>() {}.getType();
+        Type type = new TypeToken<InstanceDatastore>(){}.getType();
         return (InstanceDatastore) this.APICall("ADSModule/GetDatastore", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param datastoreId False
+     * Name Description Optional
+     * @param datastoreId  False
      * @return Result<List<Map<String, Object>>>
      */
     public Result<List<Map<String, Object>>> GetDatastoreInstances(Integer datastoreId) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("datastoreId", datastoreId);
-        Type type = new TypeToken<Result<List<Map<String, Object>>>>() {}.getType();
-        return (Result<List<Map<String, Object>>>)
-                this.APICall("ADSModule/GetDatastoreInstances", args, type);
+        Type type = new TypeToken<Result<List<Map<String, Object>>>>(){}.getType();
+        return (Result<List<Map<String, Object>>>) this.APICall("ADSModule/GetDatastoreInstances", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
+     * Name Description Optional
      * @return Result<List<InstanceDatastore>>
      */
     public Result<List<InstanceDatastore>> GetDatastores() {
         HashMap<String, Object> args = new HashMap<>();
-        Type type = new TypeToken<Result<List<InstanceDatastore>>>() {}.getType();
-        return (Result<List<InstanceDatastore>>)
-                this.APICall("ADSModule/GetDatastores", args, type);
+        Type type = new TypeToken<Result<List<InstanceDatastore>>>(){}.getType();
+        return (Result<List<InstanceDatastore>>) this.APICall("ADSModule/GetDatastores", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
+     * Name Description Optional
      * @return Result<List<Object>>
      */
     public Result<List<Object>> GetDeploymentTemplates() {
         HashMap<String, Object> args = new HashMap<>();
-        Type type = new TypeToken<Result<List<Object>>>() {}.getType();
+        Type type = new TypeToken<Result<List<Object>>>(){}.getType();
         return (Result<List<Object>>) this.APICall("ADSModule/GetDeploymentTemplates", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param GroupId False
+     * Name Description Optional
+     * @param GroupId  False
      * @return Result<IADSInstance>
      */
     public Result<IADSInstance> GetGroup(UUID GroupId) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("GroupId", GroupId);
-        Type type = new TypeToken<Result<IADSInstance>>() {}.getType();
+        Type type = new TypeToken<Result<IADSInstance>>(){}.getType();
         return (Result<IADSInstance>) this.APICall("ADSModule/GetGroup", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param InstanceId False
+     * Name Description Optional
+     * @param InstanceId  False
      * @return Result<Instance>
      */
     public Result<Instance> GetInstance(UUID InstanceId) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("InstanceId", InstanceId);
-        Type type = new TypeToken<Result<Instance>>() {}.getType();
+        Type type = new TypeToken<Result<Instance>>(){}.getType();
         return (Result<Instance>) this.APICall("ADSModule/GetInstance", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param InstanceName False
+     * Name Description Optional
+     * @param InstanceName  False
      * @return Result<List<Object>>
      */
     public Result<List<Object>> GetInstanceNetworkInfo(String InstanceName) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("InstanceName", InstanceName);
-        Type type = new TypeToken<Result<List<Object>>>() {}.getType();
+        Type type = new TypeToken<Result<List<Object>>>(){}.getType();
         return (Result<List<Object>>) this.APICall("ADSModule/GetInstanceNetworkInfo", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
+     * Name Description Optional
      * @return Result<List<Map<String, Object>>>
      */
     public Result<List<Map<String, Object>>> GetInstanceStatuses() {
         HashMap<String, Object> args = new HashMap<>();
-        Type type = new TypeToken<Result<List<Map<String, Object>>>>() {}.getType();
-        return (Result<List<Map<String, Object>>>)
-                this.APICall("ADSModule/GetInstanceStatuses", args, type);
+        Type type = new TypeToken<Result<List<Map<String, Object>>>>(){}.getType();
+        return (Result<List<Map<String, Object>>>) this.APICall("ADSModule/GetInstanceStatuses", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
+     * Name Description Optional
      * @return Result<List<IADSInstance>>
      */
     public Result<List<IADSInstance>> GetInstances() {
         HashMap<String, Object> args = new HashMap<>();
-        Type type = new TypeToken<Result<List<IADSInstance>>>() {}.getType();
+        Type type = new TypeToken<Result<List<IADSInstance>>>(){}.getType();
         return (Result<List<IADSInstance>>) this.APICall("ADSModule/GetInstances", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
+     * Name Description Optional
      * @return Result<List<Map<String, Object>>>
      */
     public Result<List<Map<String, Object>>> GetLocalInstances() {
         HashMap<String, Object> args = new HashMap<>();
-        Type type = new TypeToken<Result<List<Map<String, Object>>>>() {}.getType();
-        return (Result<List<Map<String, Object>>>)
-                this.APICall("ADSModule/GetLocalInstances", args, type);
+        Type type = new TypeToken<Result<List<Map<String, Object>>>>(){}.getType();
+        return (Result<List<Map<String, Object>>>) this.APICall("ADSModule/GetLocalInstances", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param ModuleName False
+     * Name Description Optional
+     * @param ModuleName  False
      * @return Result<List<Map<String, Object>>>
      */
     public Result<List<Map<String, Object>>> GetProvisionArguments(String ModuleName) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("ModuleName", ModuleName);
-        Type type = new TypeToken<Result<List<Map<String, Object>>>>() {}.getType();
-        return (Result<List<Map<String, Object>>>)
-                this.APICall("ADSModule/GetProvisionArguments", args, type);
+        Type type = new TypeToken<Result<List<Map<String, Object>>>>(){}.getType();
+        return (Result<List<Map<String, Object>>>) this.APICall("ADSModule/GetProvisionArguments", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
+     * Name Description Optional
      * @return Map<String, Object>
      */
     public Map<String, Object> GetProvisionFitness() {
         HashMap<String, Object> args = new HashMap<>();
-        Type type = new TypeToken<Map<String, Object>>() {}.getType();
+        Type type = new TypeToken<Map<String, Object>>(){}.getType();
         return (Map<String, Object>) this.APICall("ADSModule/GetProvisionFitness", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
+     * Name Description Optional
      * @return Result<List<Object>>
      */
     public Result<List<Object>> GetSupportedApplications() {
         HashMap<String, Object> args = new HashMap<>();
-        Type type = new TypeToken<Result<List<Object>>>() {}.getType();
-        return (Result<List<Object>>)
-                this.APICall("ADSModule/GetSupportedApplications", args, type);
+        Type type = new TypeToken<Result<List<Object>>>(){}.getType();
+        return (Result<List<Object>>) this.APICall("ADSModule/GetSupportedApplications", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
+     * Name Description Optional
      * @return Result<RemoteTargetInfo>
      */
     public Result<RemoteTargetInfo> GetTargetInfo() {
         HashMap<String, Object> args = new HashMap<>();
-        Type type = new TypeToken<Result<RemoteTargetInfo>>() {}.getType();
+        Type type = new TypeToken<Result<RemoteTargetInfo>>(){}.getType();
         return (Result<RemoteTargetInfo>) this.APICall("ADSModule/GetTargetInfo", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param ForModule False
-     * @param SettingNode False
-     * @param Values False
+     * Name Description Optional
+     * @param ForModule  False
+     * @param SettingNode  False
+     * @param Values  False
      * @return Task<ActionResult>
      */
-    public Task<ActionResult> HandoutInstanceConfigs(
-            String ForModule, String SettingNode, List<String> Values) {
+    public Task<ActionResult> HandoutInstanceConfigs(String ForModule, String SettingNode, List<String> Values) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("ForModule", ForModule);
         args.put("SettingNode", SettingNode);
         args.put("Values", Values);
-        Type type = new TypeToken<Task<ActionResult>>() {}.getType();
+        Type type = new TypeToken<Task<ActionResult>>(){}.getType();
         return (Task<ActionResult>) this.APICall("ADSModule/HandoutInstanceConfigs", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param InstanceId False
+     * Name Description Optional
+     * @param InstanceId  False
      * @return ActionResult<String>
      */
     public ActionResult<String> ManageInstance(UUID InstanceId) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("InstanceId", InstanceId);
-        Type type = new TypeToken<ActionResult<String>>() {}.getType();
+        Type type = new TypeToken<ActionResult<String>>(){}.getType();
         return (ActionResult<String>) this.APICall("ADSModule/ManageInstance", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param instanceId False
-     * @param PortNumber False
-     * @param Range False
-     * @param Protocol False
-     * @param Description False
-     * @param Open False
+     * Name Description Optional
+     * @param instanceId  False
+     * @param PortNumber  False
+     * @param Range  False
+     * @param Protocol  False
+     * @param Description  False
+     * @param Open  False
      * @return Task<ActionResult>
      */
-    public Task<ActionResult> ModifyCustomFirewallRule(
-            UUID instanceId,
-            Integer PortNumber,
-            Integer Range,
-            Object Protocol,
-            String Description,
-            Boolean Open) {
+    public Task<ActionResult> ModifyCustomFirewallRule(UUID instanceId, Integer PortNumber, Integer Range, Object Protocol, String Description, Boolean Open) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("instanceId", instanceId);
         args.put("PortNumber", PortNumber);
@@ -589,102 +557,105 @@ public class ADSModule extends AMPAPI {
         args.put("Protocol", Protocol);
         args.put("Description", Description);
         args.put("Open", Open);
-        Type type = new TypeToken<Task<ActionResult>>() {}.getType();
+        Type type = new TypeToken<Task<ActionResult>>(){}.getType();
         return (Task<ActionResult>) this.APICall("ADSModule/ModifyCustomFirewallRule", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param instanceId False
-     * @param datastoreId False
+     * Name Description Optional
+     * @param instanceId  False
+     * @param datastoreId  False
      * @return Task<RunningTask>
      */
     public Task<RunningTask> MoveInstanceDatastore(UUID instanceId, Integer datastoreId) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("instanceId", instanceId);
         args.put("datastoreId", datastoreId);
-        Type type = new TypeToken<Task<RunningTask>>() {}.getType();
+        Type type = new TypeToken<Task<RunningTask>>(){}.getType();
         return (Task<RunningTask>) this.APICall("ADSModule/MoveInstanceDatastore", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
+     * Name Description Optional
      * @return Result<RunningTask>
      */
     public Result<RunningTask> ReactivateLocalInstances() {
         HashMap<String, Object> args = new HashMap<>();
-        Type type = new TypeToken<Result<RunningTask>>() {}.getType();
+        Type type = new TypeToken<Result<RunningTask>>(){}.getType();
         return (Result<RunningTask>) this.APICall("ADSModule/ReactivateLocalInstances", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
+     * Name Description Optional
      * @return Void
      */
     public Void RefreshAppCache() {
         HashMap<String, Object> args = new HashMap<>();
-        Type type = new TypeToken<Void>() {}.getType();
+        Type type = new TypeToken<Void>(){}.getType();
         return (Void) this.APICall("ADSModule/RefreshAppCache", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param GroupId False
+     * Name Description Optional
+     * @param GroupId  False
      * @return ActionResult
      */
     public ActionResult RefreshGroup(UUID GroupId) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("GroupId", GroupId);
-        Type type = new TypeToken<ActionResult>() {}.getType();
+        Type type = new TypeToken<ActionResult>(){}.getType();
         return (ActionResult) this.APICall("ADSModule/RefreshGroup", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param InstanceId False
+     * Name Description Optional
+     * @param InstanceId  False
      * @return Task<ActionResult>
      */
     public Task<ActionResult> RefreshInstanceConfig(String InstanceId) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("InstanceId", InstanceId);
-        Type type = new TypeToken<Task<ActionResult>>() {}.getType();
+        Type type = new TypeToken<Task<ActionResult>>(){}.getType();
         return (Task<ActionResult>) this.APICall("ADSModule/RefreshInstanceConfig", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
+     * Name Description Optional
+     * @param force  True
      * @return Void
      */
-    public Void RefreshRemoteConfigStores() {
+    public Void RefreshRemoteConfigStores(Boolean force) {
         HashMap<String, Object> args = new HashMap<>();
-        Type type = new TypeToken<Void>() {}.getType();
+        args.put("force", force);
+        Type type = new TypeToken<Void>(){}.getType();
         return (Void) this.APICall("ADSModule/RefreshRemoteConfigStores", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param controllerUrl False
-     * @param myUrl False
-     * @param username False
-     * @param password False
-     * @param twoFactorToken False
-     * @param friendlyName False
+     * Name Description Optional
+     * @param controllerUrl  False
+     * @param myUrl  False
+     * @param username  False
+     * @param password  False
+     * @param twoFactorToken  False
+     * @param friendlyName  False
      * @return Task<ActionResult>
      */
-    public Task<ActionResult> RegisterTarget(
-            String controllerUrl,
-            String myUrl,
-            String username,
-            String password,
-            String twoFactorToken,
-            String friendlyName) {
+    public Task<ActionResult> RegisterTarget(String controllerUrl, String myUrl, String username, String password, String twoFactorToken, String friendlyName) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("controllerUrl", controllerUrl);
         args.put("myUrl", myUrl);
@@ -692,168 +663,177 @@ public class ADSModule extends AMPAPI {
         args.put("password", password);
         args.put("twoFactorToken", twoFactorToken);
         args.put("friendlyName", friendlyName);
-        Type type = new TypeToken<Task<ActionResult>>() {}.getType();
+        Type type = new TypeToken<Task<ActionResult>>(){}.getType();
         return (Task<ActionResult>) this.APICall("ADSModule/RegisterTarget", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param id False
+     * Name Description Optional
+     * @param id  False
      * @return Result<RunningTask>
      */
     public Result<RunningTask> RepairDatastore(Integer id) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("id", id);
-        Type type = new TypeToken<Result<RunningTask>>() {}.getType();
+        Type type = new TypeToken<Result<RunningTask>>(){}.getType();
         return (Result<RunningTask>) this.APICall("ADSModule/RepairDatastore", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param datastoreId False
+     * Name Description Optional
+     * @param datastoreId  False
      * @return Result<RunningTask>
      */
     public Result<RunningTask> RequestDatastoreSizeCalculation(Integer datastoreId) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("datastoreId", datastoreId);
-        Type type = new TypeToken<Result<RunningTask>>() {}.getType();
-        return (Result<RunningTask>)
-                this.APICall("ADSModule/RequestDatastoreSizeCalculation", args, type);
+        Type type = new TypeToken<Result<RunningTask>>(){}.getType();
+        return (Result<RunningTask>) this.APICall("ADSModule/RequestDatastoreSizeCalculation", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param InstanceName False
+     * Name Description Optional
+     * @param InstanceName  False
      * @return ActionResult
      */
     public ActionResult RestartInstance(String InstanceName) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("InstanceName", InstanceName);
-        Type type = new TypeToken<ActionResult>() {}.getType();
+        Type type = new TypeToken<ActionResult>(){}.getType();
         return (ActionResult) this.APICall("ADSModule/RestartInstance", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param id False
-     * @param REQ_RAWJSON False
+     * Name Description Optional
+     * @param id  False
+     * @param REQ_RAWJSON  False
      * @return Task<Map<String, Object>>
      */
     public Task<Map<String, Object>> Servers(String id, String REQ_RAWJSON) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("id", id);
         args.put("REQ_RAWJSON", REQ_RAWJSON);
-        Type type = new TypeToken<Task<Map<String, Object>>>() {}.getType();
+        Type type = new TypeToken<Task<Map<String, Object>>>(){}.getType();
         return (Task<Map<String, Object>>) this.APICall("ADSModule/Servers", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param InstanceName False
-     * @param SettingNode False
-     * @param Value False
+     * Name Description Optional
+     * @param InstanceName  False
+     * @param SettingNode  False
+     * @param Value  False
      * @return Task<ActionResult>
      */
-    public Task<ActionResult> SetInstanceConfig(
-            String InstanceName, String SettingNode, String Value) {
+    public Task<ActionResult> SetInstanceConfig(String InstanceName, String SettingNode, String Value) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("InstanceName", InstanceName);
         args.put("SettingNode", SettingNode);
         args.put("Value", Value);
-        Type type = new TypeToken<Task<ActionResult>>() {}.getType();
+        Type type = new TypeToken<Task<ActionResult>>(){}.getType();
         return (Task<ActionResult>) this.APICall("ADSModule/SetInstanceConfig", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param InstanceId False
-     * @param PortMappings False
+     * Name Description Optional
+     * @param InstanceId  False
+     * @param PortMappings  False
      * @return Task<ActionResult>
      */
-    public Task<ActionResult> SetInstanceNetworkInfo(
-            UUID InstanceId, Map<String, Integer> PortMappings) {
+    public Task<ActionResult> SetInstanceNetworkInfo(UUID InstanceId, Map<String, Integer> PortMappings) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("InstanceId", InstanceId);
         args.put("PortMappings", PortMappings);
-        Type type = new TypeToken<Task<ActionResult>>() {}.getType();
+        Type type = new TypeToken<Task<ActionResult>>(){}.getType();
         return (Task<ActionResult>) this.APICall("ADSModule/SetInstanceNetworkInfo", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param InstanceName False
-     * @param Suspended False
+     * Name Description Optional
+     * @param InstanceName  False
+     * @param Suspended  False
      * @return Task<ActionResult>
      */
     public Task<ActionResult> SetInstanceSuspended(String InstanceName, Boolean Suspended) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("InstanceName", InstanceName);
         args.put("Suspended", Suspended);
-        Type type = new TypeToken<Task<ActionResult>>() {}.getType();
+        Type type = new TypeToken<Task<ActionResult>>(){}.getType();
         return (Task<ActionResult>) this.APICall("ADSModule/SetInstanceSuspended", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
+     * Name Description Optional
      * @return Task<ActionResult>
      */
     public Task<ActionResult> StartAllInstances() {
         HashMap<String, Object> args = new HashMap<>();
-        Type type = new TypeToken<Task<ActionResult>>() {}.getType();
+        Type type = new TypeToken<Task<ActionResult>>(){}.getType();
         return (Task<ActionResult>) this.APICall("ADSModule/StartAllInstances", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param InstanceName False
+     * Name Description Optional
+     * @param InstanceName  False
      * @return Task<ActionResult>
      */
     public Task<ActionResult> StartInstance(String InstanceName) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("InstanceName", InstanceName);
-        Type type = new TypeToken<Task<ActionResult>>() {}.getType();
+        Type type = new TypeToken<Task<ActionResult>>(){}.getType();
         return (Task<ActionResult>) this.APICall("ADSModule/StartInstance", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
+     * Name Description Optional
      * @return Task<ActionResult>
      */
     public Task<ActionResult> StopAllInstances() {
         HashMap<String, Object> args = new HashMap<>();
-        Type type = new TypeToken<Task<ActionResult>>() {}.getType();
+        Type type = new TypeToken<Task<ActionResult>>(){}.getType();
         return (Task<ActionResult>) this.APICall("ADSModule/StopAllInstances", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param InstanceName False
+     * Name Description Optional
+     * @param InstanceName  False
      * @return ActionResult
      */
     public ActionResult StopInstance(String InstanceName) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("InstanceName", InstanceName);
-        Type type = new TypeToken<ActionResult>() {}.getType();
+        Type type = new TypeToken<ActionResult>(){}.getType();
         return (ActionResult) this.APICall("ADSModule/StopInstance", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param url False
-     * @param username False
-     * @param password False
+     * Name Description Optional
+     * @param url  False
+     * @param username  False
+     * @param password  False
      * @return Task<ActionResult>
      */
     public Task<ActionResult> TestADSLoginDetails(String url, String username, String password) {
@@ -861,64 +841,56 @@ public class ADSModule extends AMPAPI {
         args.put("url", url);
         args.put("username", username);
         args.put("password", password);
-        Type type = new TypeToken<Task<ActionResult>>() {}.getType();
+        Type type = new TypeToken<Task<ActionResult>>(){}.getType();
         return (Task<ActionResult>) this.APICall("ADSModule/TestADSLoginDetails", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param updatedDatastore False
+     * Name Description Optional
+     * @param updatedDatastore  False
      * @return ActionResult
      */
     public ActionResult UpdateDatastore(InstanceDatastore updatedDatastore) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("updatedDatastore", updatedDatastore);
-        Type type = new TypeToken<ActionResult>() {}.getType();
+        Type type = new TypeToken<ActionResult>(){}.getType();
         return (ActionResult) this.APICall("ADSModule/UpdateDatastore", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param templateToUpdate False
+     * Name Description Optional
+     * @param templateToUpdate  False
      * @return ActionResult
      */
     public ActionResult UpdateDeploymentTemplate(Object templateToUpdate) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("templateToUpdate", templateToUpdate);
-        Type type = new TypeToken<ActionResult>() {}.getType();
+        Type type = new TypeToken<ActionResult>(){}.getType();
         return (ActionResult) this.APICall("ADSModule/UpdateDeploymentTemplate", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param InstanceId False
-     * @param FriendlyName False
-     * @param Description False
-     * @param StartOnBoot False
-     * @param Suspended False
-     * @param ExcludeFromFirewall False
-     * @param RunInContainer False
-     * @param ContainerMemory False
-     * @param MemoryPolicy False
-     * @param ContainerMaxCPU False
-     * @param ContainerImage False
-     * @return Task<ActionResult>
+     * Name Description Optional
+     * @param InstanceId  False
+     * @param FriendlyName  False
+     * @param Description  False
+     * @param StartOnBoot  False
+     * @param Suspended  False
+     * @param ExcludeFromFirewall  False
+     * @param RunInContainer  False
+     * @param ContainerMemory  False
+     * @param MemoryPolicy  False
+     * @param ContainerMaxCPU  False
+     * @param ContainerImage  False
+     * @return ActionResult
      */
-    public Task<ActionResult> UpdateInstanceInfo(
-            String InstanceId,
-            String FriendlyName,
-            String Description,
-            Boolean StartOnBoot,
-            Boolean Suspended,
-            Boolean ExcludeFromFirewall,
-            Boolean RunInContainer,
-            Integer ContainerMemory,
-            Object MemoryPolicy,
-            Object ContainerMaxCPU,
-            String ContainerImage) {
+    public ActionResult UpdateInstanceInfo(String InstanceId, String FriendlyName, String Description, Boolean StartOnBoot, Boolean Suspended, Boolean ExcludeFromFirewall, Boolean RunInContainer, Integer ContainerMemory, Object MemoryPolicy, Object ContainerMaxCPU, String ContainerImage) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("InstanceId", InstanceId);
         args.put("FriendlyName", FriendlyName);
@@ -931,68 +903,72 @@ public class ADSModule extends AMPAPI {
         args.put("MemoryPolicy", MemoryPolicy);
         args.put("ContainerMaxCPU", ContainerMaxCPU);
         args.put("ContainerImage", ContainerImage);
-        Type type = new TypeToken<Task<ActionResult>>() {}.getType();
-        return (Task<ActionResult>) this.APICall("ADSModule/UpdateInstanceInfo", args, type);
+        Type type = new TypeToken<ActionResult>(){}.getType();
+        return (ActionResult) this.APICall("ADSModule/UpdateInstanceInfo", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param TargetID False
+     * Name Description Optional
+     * @param TargetID  False
      * @return Void
      */
     public Void UpdateTarget(UUID TargetID) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("TargetID", TargetID);
-        Type type = new TypeToken<Void>() {}.getType();
+        Type type = new TypeToken<Void>(){}.getType();
         return (Void) this.APICall("ADSModule/UpdateTarget", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param Id False
-     * @param FriendlyName False
-     * @param Url False
-     * @param Description False
-     * @param Tags False
+     * Name Description Optional
+     * @param Id  False
+     * @param FriendlyName  False
+     * @param Url  False
+     * @param Description  False
+     * @param Tags  False
      * @return ActionResult
      */
-    public ActionResult UpdateTargetInfo(
-            UUID Id, String FriendlyName, URL Url, String Description, List<String> Tags) {
+    public ActionResult UpdateTargetInfo(UUID Id, String FriendlyName, URL Url, String Description, List<String> Tags) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("Id", Id);
         args.put("FriendlyName", FriendlyName);
         args.put("Url", Url);
         args.put("Description", Description);
         args.put("Tags", Tags);
-        Type type = new TypeToken<ActionResult>() {}.getType();
+        Type type = new TypeToken<ActionResult>(){}.getType();
         return (ActionResult) this.APICall("ADSModule/UpdateTargetInfo", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param RestartRunning False
+     * Name Description Optional
+     * @param RestartRunning  False
      * @return Task<ActionResult>
      */
     public Task<ActionResult> UpgradeAllInstances(Boolean RestartRunning) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("RestartRunning", RestartRunning);
-        Type type = new TypeToken<Task<ActionResult>>() {}.getType();
+        Type type = new TypeToken<Task<ActionResult>>(){}.getType();
         return (Task<ActionResult>) this.APICall("ADSModule/UpgradeAllInstances", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param InstanceName False
+     * Name Description Optional
+     * @param InstanceName  False
      * @return ActionResult
      */
     public ActionResult UpgradeInstance(String InstanceName) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("InstanceName", InstanceName);
-        Type type = new TypeToken<ActionResult>() {}.getType();
+        Type type = new TypeToken<ActionResult>(){}.getType();
         return (ActionResult) this.APICall("ADSModule/UpgradeInstance", args, type);
     }
+
 }

--- a/src/main/java/dev/neuralnexus/ampapi/apimodules/Core.java
+++ b/src/main/java/dev/neuralnexus/ampapi/apimodules/Core.java
@@ -6,6 +6,7 @@ import dev.neuralnexus.ampapi.AMPAPI;
 import dev.neuralnexus.ampapi.types.*;
 
 import java.lang.reflect.Type;
+import java.net.URL;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -17,64 +18,60 @@ public class Core extends AMPAPI {
     }
 
     /**
-     * Name Description Optional
+     * 
      *
+     * Name Description Optional
      * @return Void
      */
     public Void AcknowledgeAMPUpdate() {
         HashMap<String, Object> args = new HashMap<>();
-        Type type = new TypeToken<Void>() {}.getType();
+        Type type = new TypeToken<Void>(){}.getType();
         return (Void) this.APICall("Core/AcknowledgeAMPUpdate", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param LicenceKey False
-     * @param QueryOnly True
+     * Name Description Optional
+     * @param LicenceKey  False
+     * @param QueryOnly  True
      * @return Task<ActionResult<LicenceInfo>>
      */
-    public Task<ActionResult<LicenceInfo>> ActivateAMPLicence(
-            String LicenceKey, Boolean QueryOnly) {
+    public Task<ActionResult<LicenceInfo>> ActivateAMPLicence(String LicenceKey, Boolean QueryOnly) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("LicenceKey", LicenceKey);
         args.put("QueryOnly", QueryOnly);
-        Type type = new TypeToken<Task<ActionResult<LicenceInfo>>>() {}.getType();
-        return (Task<ActionResult<LicenceInfo>>)
-                this.APICall("Core/ActivateAMPLicence", args, type);
+        Type type = new TypeToken<Task<ActionResult<LicenceInfo>>>(){}.getType();
+        return (Task<ActionResult<LicenceInfo>>) this.APICall("Core/ActivateAMPLicence", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param triggerId False
+     * Name Description Optional
+     * @param triggerId  False
      * @return ActionResult
      */
     public ActionResult AddEventTrigger(UUID triggerId) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("triggerId", triggerId);
-        Type type = new TypeToken<ActionResult>() {}.getType();
+        Type type = new TypeToken<ActionResult>(){}.getType();
         return (ActionResult) this.APICall("Core/AddEventTrigger", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param months False
-     * @param days False
-     * @param hours False
-     * @param minutes False
-     * @param daysOfMonth False
-     * @param description False
+     * Name Description Optional
+     * @param months  False
+     * @param days  False
+     * @param hours  False
+     * @param minutes  False
+     * @param daysOfMonth  False
+     * @param description  False
      * @return ActionResult
      */
-    public ActionResult AddIntervalTrigger(
-            List<Integer> months,
-            List<Integer> days,
-            List<Integer> hours,
-            List<Integer> minutes,
-            List<Integer> daysOfMonth,
-            String description) {
+    public ActionResult AddIntervalTrigger(List<Integer> months, List<Integer> days, List<Integer> hours, List<Integer> minutes, List<Integer> daysOfMonth, String description) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("months", months);
         args.put("days", days);
@@ -82,58 +79,62 @@ public class Core extends AMPAPI {
         args.put("minutes", minutes);
         args.put("daysOfMonth", daysOfMonth);
         args.put("description", description);
-        Type type = new TypeToken<ActionResult>() {}.getType();
+        Type type = new TypeToken<ActionResult>(){}.getType();
         return (ActionResult) this.APICall("Core/AddIntervalTrigger", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param TriggerID False
-     * @param MethodID False
-     * @param ParameterMapping False
+     * Name Description Optional
+     * @param TriggerID  False
+     * @param MethodID  False
+     * @param ParameterMapping  False
      * @return ActionResult
      */
-    public ActionResult AddTask(
-            UUID TriggerID, String MethodID, Map<String, String> ParameterMapping) {
+    public ActionResult AddTask(UUID TriggerID, String MethodID, Map<String, String> ParameterMapping) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("TriggerID", TriggerID);
         args.put("MethodID", MethodID);
         args.put("ParameterMapping", ParameterMapping);
-        Type type = new TypeToken<ActionResult>() {}.getType();
+        Type type = new TypeToken<ActionResult>(){}.getType();
         return (ActionResult) this.APICall("Core/AddTask", args, type);
     }
 
     /**
-     * DEV: Async test method Name Description Optional
+     * 
+     * DEV: Async test method
      *
+     * Name Description Optional
      * @return Task<String>
      */
     public Task<String> AsyncTest() {
         HashMap<String, Object> args = new HashMap<>();
-        Type type = new TypeToken<Task<String>>() {}.getType();
+        Type type = new TypeToken<Task<String>>(){}.getType();
         return (Task<String>) this.APICall("Core/AsyncTest", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param TaskId False
+     * Name Description Optional
+     * @param TaskId  False
      * @return ActionResult
      */
     public ActionResult CancelTask(UUID TaskId) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("TaskId", TaskId);
-        Type type = new TypeToken<ActionResult>() {}.getType();
+        Type type = new TypeToken<ActionResult>(){}.getType();
         return (ActionResult) this.APICall("Core/CancelTask", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param TriggerID False
-     * @param TaskID False
-     * @param NewOrder False
+     * Name Description Optional
+     * @param TriggerID  False
+     * @param TaskID  False
+     * @param NewOrder  False
      * @return ActionResult
      */
     public ActionResult ChangeTaskOrder(UUID TriggerID, UUID TaskID, Integer NewOrder) {
@@ -141,224 +142,231 @@ public class Core extends AMPAPI {
         args.put("TriggerID", TriggerID);
         args.put("TaskID", TaskID);
         args.put("NewOrder", NewOrder);
-        Type type = new TypeToken<ActionResult>() {}.getType();
+        Type type = new TypeToken<ActionResult>(){}.getType();
         return (ActionResult) this.APICall("Core/ChangeTaskOrder", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param Username False
-     * @param OldPassword False
-     * @param NewPassword False
-     * @param TwoFactorPIN False
+     * Name Description Optional
+     * @param Username  False
+     * @param OldPassword  False
+     * @param NewPassword  False
+     * @param TwoFactorPIN  False
      * @return Task<ActionResult>
      */
-    public Task<ActionResult> ChangeUserPassword(
-            String Username, String OldPassword, String NewPassword, String TwoFactorPIN) {
+    public Task<ActionResult> ChangeUserPassword(String Username, String OldPassword, String NewPassword, String TwoFactorPIN) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("Username", Username);
         args.put("OldPassword", OldPassword);
         args.put("NewPassword", NewPassword);
         args.put("TwoFactorPIN", TwoFactorPIN);
-        Type type = new TypeToken<Task<ActionResult>>() {}.getType();
+        Type type = new TypeToken<Task<ActionResult>>(){}.getType();
         return (Task<ActionResult>) this.APICall("Core/ChangeUserPassword", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param Username False
-     * @param TwoFactorCode False
+     * Name Description Optional
+     * @param Username  False
+     * @param TwoFactorCode  False
      * @return Task<ActionResult>
      */
     public Task<ActionResult> ConfirmTwoFactorSetup(String Username, String TwoFactorCode) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("Username", Username);
         args.put("TwoFactorCode", TwoFactorCode);
-        Type type = new TypeToken<Task<ActionResult>>() {}.getType();
+        Type type = new TypeToken<Task<ActionResult>>(){}.getType();
         return (Task<ActionResult>) this.APICall("Core/ConfirmTwoFactorSetup", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param Name False
-     * @param AsCommonRole True
+     * Name Description Optional
+     * @param Name  False
+     * @param AsCommonRole  True
      * @return Task<ActionResult<UUID>>
      */
     public Task<ActionResult<UUID>> CreateRole(String Name, Boolean AsCommonRole) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("Name", Name);
         args.put("AsCommonRole", AsCommonRole);
-        Type type = new TypeToken<Task<ActionResult<UUID>>>() {}.getType();
+        Type type = new TypeToken<Task<ActionResult<UUID>>>(){}.getType();
         return (Task<ActionResult<UUID>>) this.APICall("Core/CreateRole", args, type);
     }
 
     /**
-     * DEV: Creates a non-ending task with 50% progress for testing purposes Name Description
-     * Optional
+     * 
+     * DEV: Creates a non-ending task with 50% progress for testing purposes
      *
+     * Name Description Optional
      * @return Void
      */
     public Void CreateTestTask() {
         HashMap<String, Object> args = new HashMap<>();
-        Type type = new TypeToken<Void>() {}.getType();
+        Type type = new TypeToken<Void>(){}.getType();
         return (Void) this.APICall("Core/CreateTestTask", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param Username False
+     * Name Description Optional
+     * @param Username  False
      * @return Task<ActionResult<UUID>>
      */
     public Task<ActionResult<UUID>> CreateUser(String Username) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("Username", Username);
-        Type type = new TypeToken<Task<ActionResult<UUID>>>() {}.getType();
+        Type type = new TypeToken<Task<ActionResult<UUID>>>(){}.getType();
         return (Task<ActionResult<UUID>>) this.APICall("Core/CreateUser", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param PermissionNode False
+     * Name Description Optional
+     * @param PermissionNode  False
      * @return Boolean
      */
     public Boolean CurrentSessionHasPermission(String PermissionNode) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("PermissionNode", PermissionNode);
-        Type type = new TypeToken<Boolean>() {}.getType();
+        Type type = new TypeToken<Boolean>(){}.getType();
         return (Boolean) this.APICall("Core/CurrentSessionHasPermission", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param InstanceId False
+     * Name Description Optional
+     * @param InstanceId  False
      * @return Task<ActionResult>
      */
     public Task<ActionResult> DeleteInstanceUsers(UUID InstanceId) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("InstanceId", InstanceId);
-        Type type = new TypeToken<Task<ActionResult>>() {}.getType();
+        Type type = new TypeToken<Task<ActionResult>>(){}.getType();
         return (Task<ActionResult>) this.APICall("Core/DeleteInstanceUsers", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param RoleId False
+     * Name Description Optional
+     * @param RoleId  False
      * @return Task<ActionResult>
      */
     public Task<ActionResult> DeleteRole(UUID RoleId) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("RoleId", RoleId);
-        Type type = new TypeToken<Task<ActionResult>>() {}.getType();
+        Type type = new TypeToken<Task<ActionResult>>(){}.getType();
         return (Task<ActionResult>) this.APICall("Core/DeleteRole", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param TriggerID False
-     * @param TaskID False
+     * Name Description Optional
+     * @param TriggerID  False
+     * @param TaskID  False
      * @return ActionResult
      */
     public ActionResult DeleteTask(UUID TriggerID, UUID TaskID) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("TriggerID", TriggerID);
         args.put("TaskID", TaskID);
-        Type type = new TypeToken<ActionResult>() {}.getType();
+        Type type = new TypeToken<ActionResult>(){}.getType();
         return (ActionResult) this.APICall("Core/DeleteTask", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param TriggerID False
+     * Name Description Optional
+     * @param TriggerID  False
      * @return ActionResult
      */
     public ActionResult DeleteTrigger(UUID TriggerID) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("TriggerID", TriggerID);
-        Type type = new TypeToken<ActionResult>() {}.getType();
+        Type type = new TypeToken<ActionResult>(){}.getType();
         return (ActionResult) this.APICall("Core/DeleteTrigger", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param Username False
+     * Name Description Optional
+     * @param Username  False
      * @return Task<ActionResult>
      */
     public Task<ActionResult> DeleteUser(String Username) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("Username", Username);
-        Type type = new TypeToken<Task<ActionResult>>() {}.getType();
+        Type type = new TypeToken<Task<ActionResult>>(){}.getType();
         return (Task<ActionResult>) this.APICall("Core/DeleteUser", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param Password False
-     * @param TwoFactorCode False
+     * Name Description Optional
+     * @param Password  False
+     * @param TwoFactorCode  False
      * @return Task<ActionResult>
      */
     public Task<ActionResult> DisableTwoFactor(String Password, String TwoFactorCode) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("Password", Password);
         args.put("TwoFactorCode", TwoFactorCode);
-        Type type = new TypeToken<Task<ActionResult>>() {}.getType();
+        Type type = new TypeToken<Task<ActionResult>>(){}.getType();
         return (Task<ActionResult>) this.APICall("Core/DisableTwoFactor", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
+     * Name Description Optional
      * @return ActionResult
      */
     public ActionResult DismissAllTasks() {
         HashMap<String, Object> args = new HashMap<>();
-        Type type = new TypeToken<ActionResult>() {}.getType();
+        Type type = new TypeToken<ActionResult>(){}.getType();
         return (ActionResult) this.APICall("Core/DismissAllTasks", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param TaskId False
+     * Name Description Optional
+     * @param TaskId  False
      * @return ActionResult
      */
     public ActionResult DismissTask(UUID TaskId) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("TaskId", TaskId);
-        Type type = new TypeToken<ActionResult>() {}.getType();
+        Type type = new TypeToken<ActionResult>(){}.getType();
         return (ActionResult) this.APICall("Core/DismissTask", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param Id False
-     * @param months False
-     * @param days False
-     * @param hours False
-     * @param minutes False
-     * @param daysOfMonth False
-     * @param description False
+     * Name Description Optional
+     * @param Id  False
+     * @param months  False
+     * @param days  False
+     * @param hours  False
+     * @param minutes  False
+     * @param daysOfMonth  False
+     * @param description  False
      * @return ActionResult
      */
-    public ActionResult EditIntervalTrigger(
-            UUID Id,
-            List<Integer> months,
-            List<Integer> days,
-            List<Integer> hours,
-            List<Integer> minutes,
-            List<Integer> daysOfMonth,
-            String description) {
+    public ActionResult EditIntervalTrigger(UUID Id, List<Integer> months, List<Integer> days, List<Integer> hours, List<Integer> minutes, List<Integer> daysOfMonth, String description) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("Id", Id);
         args.put("months", months);
@@ -367,479 +375,516 @@ public class Core extends AMPAPI {
         args.put("minutes", minutes);
         args.put("daysOfMonth", daysOfMonth);
         args.put("description", description);
-        Type type = new TypeToken<ActionResult>() {}.getType();
+        Type type = new TypeToken<ActionResult>(){}.getType();
         return (ActionResult) this.APICall("Core/EditIntervalTrigger", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param TriggerID False
-     * @param TaskID False
-     * @param ParameterMapping False
+     * Name Description Optional
+     * @param TriggerID  False
+     * @param TaskID  False
+     * @param ParameterMapping  False
      * @return ActionResult
      */
-    public ActionResult EditTask(
-            UUID TriggerID, UUID TaskID, Map<String, String> ParameterMapping) {
+    public ActionResult EditTask(UUID TriggerID, UUID TaskID, Map<String, String> ParameterMapping) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("TriggerID", TriggerID);
         args.put("TaskID", TaskID);
         args.put("ParameterMapping", ParameterMapping);
-        Type type = new TypeToken<ActionResult>() {}.getType();
+        Type type = new TypeToken<ActionResult>(){}.getType();
         return (ActionResult) this.APICall("Core/EditTask", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param Username False
-     * @param Password False
+     * Name Description Optional
+     * @param Username  False
+     * @param Password  False
      * @return Task<Object>
      */
     public Task<Object> EnableTwoFactor(String Username, String Password) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("Username", Username);
         args.put("Password", Password);
-        Type type = new TypeToken<Task<Object>>() {}.getType();
+        Type type = new TypeToken<Task<Object>>(){}.getType();
         return (Task<Object>) this.APICall("Core/EnableTwoFactor", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param Id False
+     * Name Description Optional
+     * @param Id  False
      * @return Void
      */
     public Void EndUserSession(UUID Id) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("Id", Id);
-        Type type = new TypeToken<Void>() {}.getType();
+        Type type = new TypeToken<Void>(){}.getType();
         return (Void) this.APICall("Core/EndUserSession", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param RoleId False
+     * Name Description Optional
+     * @param RoleId  False
      * @return Task<List<String>>
      */
     public Task<List<String>> GetAMPRolePermissions(UUID RoleId) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("RoleId", RoleId);
-        Type type = new TypeToken<Task<List<String>>>() {}.getType();
+        Type type = new TypeToken<Task<List<String>>>(){}.getType();
         return (Task<List<String>>) this.APICall("Core/GetAMPRolePermissions", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param Username False
+     * Name Description Optional
+     * @param Username  False
      * @return Task<UserInfo>
      */
     public Task<UserInfo> GetAMPUserInfo(String Username) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("Username", Username);
-        Type type = new TypeToken<Task<UserInfo>>() {}.getType();
+        Type type = new TypeToken<Task<UserInfo>>(){}.getType();
         return (Task<UserInfo>) this.APICall("Core/GetAMPUserInfo", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
+     * Name Description Optional
      * @return Task<List<Object>>
      */
     public Task<List<Object>> GetAMPUsersSummary() {
         HashMap<String, Object> args = new HashMap<>();
-        Type type = new TypeToken<Task<List<Object>>>() {}.getType();
+        Type type = new TypeToken<Task<List<Object>>>(){}.getType();
         return (Task<List<Object>>) this.APICall("Core/GetAMPUsersSummary", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
+     * Name Description Optional
      * @return Map<String, Map<String, Object>>
      */
     public Map<String, Map<String, Object>> GetAPISpec() {
         HashMap<String, Object> args = new HashMap<>();
-        Type type = new TypeToken<Map<String, Map<String, Object>>>() {}.getType();
+        Type type = new TypeToken<Map<String, Map<String, Object>>>(){}.getType();
         return (Map<String, Map<String, Object>>) this.APICall("Core/GetAPISpec", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
+     * Name Description Optional
      * @return Result<List<Object>>
      */
     public Result<List<Object>> GetActiveAMPSessions() {
         HashMap<String, Object> args = new HashMap<>();
-        Type type = new TypeToken<Result<List<Object>>>() {}.getType();
+        Type type = new TypeToken<Result<List<Object>>>(){}.getType();
         return (Result<List<Object>>) this.APICall("Core/GetActiveAMPSessions", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
+     * Name Description Optional
      * @return Task<List<UserInfo>>
      */
     public Task<List<UserInfo>> GetAllAMPUserInfo() {
         HashMap<String, Object> args = new HashMap<>();
-        Type type = new TypeToken<Task<List<UserInfo>>>() {}.getType();
+        Type type = new TypeToken<Task<List<UserInfo>>>(){}.getType();
         return (Task<List<UserInfo>>) this.APICall("Core/GetAllAMPUserInfo", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param Before False
-     * @param Count False
+     * Name Description Optional
+     * @param Before  False
+     * @param Count  False
      * @return Result<List<Object>>
      */
     public Result<List<Object>> GetAuditLogEntries(Object Before, Integer Count) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("Before", Before);
         args.put("Count", Count);
-        Type type = new TypeToken<Result<List<Object>>>() {}.getType();
+        Type type = new TypeToken<Result<List<Object>>>(){}.getType();
         return (Result<List<Object>>) this.APICall("Core/GetAuditLogEntries", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param node False
+     * Name Description Optional
+     * @param node  False
      * @return Map<String, Object>
      */
     public Map<String, Object> GetConfig(String node) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("node", node);
-        Type type = new TypeToken<Map<String, Object>>() {}.getType();
+        Type type = new TypeToken<Map<String, Object>>(){}.getType();
         return (Map<String, Object>) this.APICall("Core/GetConfig", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param nodes False
+     * Name Description Optional
+     * @param nodes  False
      * @return Result<List<Map<String, Object>>>
      */
     public Result<List<Map<String, Object>>> GetConfigs(List<String> nodes) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("nodes", nodes);
-        Type type = new TypeToken<Result<List<Map<String, Object>>>>() {}.getType();
+        Type type = new TypeToken<Result<List<Map<String, Object>>>>(){}.getType();
         return (Result<List<Map<String, Object>>>) this.APICall("Core/GetConfigs", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
+     * Name Description Optional
      * @return Map<String, String>
      */
     public Map<String, String> GetDiagnosticsInfo() {
         HashMap<String, Object> args = new HashMap<>();
-        Type type = new TypeToken<Map<String, String>>() {}.getType();
+        Type type = new TypeToken<Map<String, String>>(){}.getType();
         return (Map<String, String>) this.APICall("Core/GetDiagnosticsInfo", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
+     * Name Description Optional
      * @return Result<ModuleInfo>
      */
     public Result<ModuleInfo> GetModuleInfo() {
         HashMap<String, Object> args = new HashMap<>();
-        Type type = new TypeToken<Result<ModuleInfo>>() {}.getType();
+        Type type = new TypeToken<Result<ModuleInfo>>(){}.getType();
         return (Result<ModuleInfo>) this.APICall("Core/GetModuleInfo", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
+     * Name Description Optional
      * @return UUID
      */
     public UUID GetNewGuid() {
         HashMap<String, Object> args = new HashMap<>();
-        Type type = new TypeToken<UUID>() {}.getType();
+        Type type = new TypeToken<UUID>(){}.getType();
         return (UUID) this.APICall("Core/GetNewGuid", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
+     * Name Description Optional
      * @return List<Object>
      */
     public List<Object> GetPermissionsSpec() {
         HashMap<String, Object> args = new HashMap<>();
-        Type type = new TypeToken<List<Object>>() {}.getType();
+        Type type = new TypeToken<List<Object>>(){}.getType();
         return (List<Object>) this.APICall("Core/GetPermissionsSpec", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
+     * Name Description Optional
      * @return Result<List<Object>>
      */
     public Result<List<Object>> GetPortSummaries() {
         HashMap<String, Object> args = new HashMap<>();
-        Type type = new TypeToken<Result<List<Object>>>() {}.getType();
+        Type type = new TypeToken<Result<List<Object>>>(){}.getType();
         return (Result<List<Object>>) this.APICall("Core/GetPortSummaries", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
+     * Name Description Optional
      * @return List<Map<String, Object>>
      */
     public List<Map<String, Object>> GetProvisionSpec() {
         HashMap<String, Object> args = new HashMap<>();
-        Type type = new TypeToken<List<Map<String, Object>>>() {}.getType();
+        Type type = new TypeToken<List<Map<String, Object>>>(){}.getType();
         return (List<Map<String, Object>>) this.APICall("Core/GetProvisionSpec", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param Description True
-     * @param IsTemporary True
+     * Name Description Optional
+     * @param Description  True
+     * @param IsTemporary  True
      * @return Task<String>
      */
     public Task<String> GetRemoteLoginToken(String Description, Boolean IsTemporary) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("Description", Description);
         args.put("IsTemporary", IsTemporary);
-        Type type = new TypeToken<Task<String>>() {}.getType();
+        Type type = new TypeToken<Task<String>>(){}.getType();
         return (Task<String>) this.APICall("Core/GetRemoteLoginToken", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param RoleId False
+     * Name Description Optional
+     * @param RoleId  False
      * @return Task<Object>
      */
     public Task<Object> GetRole(UUID RoleId) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("RoleId", RoleId);
-        Type type = new TypeToken<Task<Object>>() {}.getType();
+        Type type = new TypeToken<Task<Object>>(){}.getType();
         return (Task<Object>) this.APICall("Core/GetRole", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
+     * Name Description Optional
      * @return Task<List<Object>>
      */
     public Task<List<Object>> GetRoleData() {
         HashMap<String, Object> args = new HashMap<>();
-        Type type = new TypeToken<Task<List<Object>>>() {}.getType();
+        Type type = new TypeToken<Task<List<Object>>>(){}.getType();
         return (Task<List<Object>>) this.APICall("Core/GetRoleData", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
+     * Name Description Optional
      * @return Task<Map<UUID, String>>
      */
     public Task<Map<UUID, String>> GetRoleIds() {
         HashMap<String, Object> args = new HashMap<>();
-        Type type = new TypeToken<Task<Map<UUID, String>>>() {}.getType();
+        Type type = new TypeToken<Task<Map<UUID, String>>>(){}.getType();
         return (Task<Map<UUID, String>>) this.APICall("Core/GetRoleIds", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
+     * Name Description Optional
      * @return Object
      */
     public Object GetScheduleData() {
         HashMap<String, Object> args = new HashMap<>();
-        Type type = new TypeToken<Object>() {}.getType();
-        return this.APICall("Core/GetScheduleData", args, type);
+        Type type = new TypeToken<Object>(){}.getType();
+        return (Object) this.APICall("Core/GetScheduleData", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param SettingNode False
-     * @param WithRefresh True
+     * Name Description Optional
+     * @param SettingNode  False
+     * @param WithRefresh  True
      * @return Map<String, String>
      */
     public Map<String, String> GetSettingValues(String SettingNode, Boolean WithRefresh) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("SettingNode", SettingNode);
         args.put("WithRefresh", WithRefresh);
-        Type type = new TypeToken<Map<String, String>>() {}.getType();
+        Type type = new TypeToken<Map<String, String>>(){}.getType();
         return (Map<String, String>) this.APICall("Core/GetSettingValues", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
+     * Name Description Optional
      * @return SettingsSpec
      */
     public SettingsSpec GetSettingsSpec() {
         HashMap<String, Object> args = new HashMap<>();
-        Type type = new TypeToken<SettingsSpec>() {}.getType();
+        Type type = new TypeToken<SettingsSpec>(){}.getType();
         return (SettingsSpec) this.APICall("Core/GetSettingsSpec", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
+     * Name Description Optional
      * @return Status
      */
     public Status GetStatus() {
         HashMap<String, Object> args = new HashMap<>();
-        Type type = new TypeToken<Status>() {}.getType();
+        Type type = new TypeToken<Status>(){}.getType();
         return (Status) this.APICall("Core/GetStatus", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
+     * Name Description Optional
      * @return Result<List<RunningTask>>
      */
     public Result<List<RunningTask>> GetTasks() {
         HashMap<String, Object> args = new HashMap<>();
-        Type type = new TypeToken<Result<List<RunningTask>>>() {}.getType();
+        Type type = new TypeToken<Result<List<RunningTask>>>(){}.getType();
         return (Result<List<RunningTask>>) this.APICall("Core/GetTasks", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param Id False
+     * Name Description Optional
+     * @param Id  False
      * @return Object
      */
     public Object GetTimeIntervalTrigger(UUID Id) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("Id", Id);
-        Type type = new TypeToken<Object>() {}.getType();
-        return this.APICall("Core/GetTimeIntervalTrigger", args, type);
+        Type type = new TypeToken<Object>(){}.getType();
+        return (Object) this.APICall("Core/GetTimeIntervalTrigger", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
+     * Name Description Optional
      * @return Result<UpdateInfo>
      */
     public Result<UpdateInfo> GetUpdateInfo() {
         HashMap<String, Object> args = new HashMap<>();
-        Type type = new TypeToken<Result<UpdateInfo>>() {}.getType();
+        Type type = new TypeToken<Result<UpdateInfo>>(){}.getType();
         return (Result<UpdateInfo>) this.APICall("Core/GetUpdateInfo", args, type);
     }
 
     /**
-     * Gets changes to the server status, in addition to any notifications or console output that
-     * have occured since the last time GetUpdates() was called by the current session. Name
-     * Description Optional
+     * 
+     * Gets changes to the server status, in addition to any notifications or console output that have occured since the last time GetUpdates() was called by the current session.
      *
+     * Name Description Optional
      * @return Updates
      */
     public Updates GetUpdates() {
         HashMap<String, Object> args = new HashMap<>();
-        Type type = new TypeToken<Updates>() {}.getType();
+        Type type = new TypeToken<Updates>(){}.getType();
         return (Updates) this.APICall("Core/GetUpdates", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
+     * Name Description Optional
      * @return Object
      */
     public Object GetUserActionsSpec() {
         HashMap<String, Object> args = new HashMap<>();
-        Type type = new TypeToken<Object>() {}.getType();
-        return this.APICall("Core/GetUserActionsSpec", args, type);
+        Type type = new TypeToken<Object>(){}.getType();
+        return (Object) this.APICall("Core/GetUserActionsSpec", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param UID False
+     * Name Description Optional
+     * @param UID  False
      * @return Map<String, Object>
      */
     public Map<String, Object> GetUserInfo(String UID) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("UID", UID);
-        Type type = new TypeToken<Map<String, Object>>() {}.getType();
+        Type type = new TypeToken<Map<String, Object>>(){}.getType();
         return (Map<String, Object>) this.APICall("Core/GetUserInfo", args, type);
     }
 
     /**
-     * Returns a list of in-application users Name Description Optional
+     * 
+     * Returns a list of in-application users
      *
+     * Name Description Optional
      * @return Result<Map<String, String>>
      */
     public Result<Map<String, String>> GetUserList() {
         HashMap<String, Object> args = new HashMap<>();
-        Type type = new TypeToken<Result<Map<String, String>>>() {}.getType();
+        Type type = new TypeToken<Result<Map<String, String>>>(){}.getType();
         return (Result<Map<String, String>>) this.APICall("Core/GetUserList", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
+     * Name Description Optional
      * @return ActionResult<String>
      */
     public ActionResult<String> GetWebauthnChallenge() {
         HashMap<String, Object> args = new HashMap<>();
-        Type type = new TypeToken<ActionResult<String>>() {}.getType();
+        Type type = new TypeToken<ActionResult<String>>(){}.getType();
         return (ActionResult<String>) this.APICall("Core/GetWebauthnChallenge", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param username False
+     * Name Description Optional
+     * @param username  False
      * @return Object
      */
     public Object GetWebauthnCredentialIDs(String username) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("username", username);
-        Type type = new TypeToken<Object>() {}.getType();
-        return this.APICall("Core/GetWebauthnCredentialIDs", args, type);
+        Type type = new TypeToken<Object>(){}.getType();
+        return (Object) this.APICall("Core/GetWebauthnCredentialIDs", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
+     * Name Description Optional
      * @return Result<List<Object>>
      */
     public Result<List<Object>> GetWebauthnCredentialSummaries() {
         HashMap<String, Object> args = new HashMap<>();
-        Type type = new TypeToken<Result<List<Object>>>() {}.getType();
-        return (Result<List<Object>>)
-                this.APICall("Core/GetWebauthnCredentialSummaries", args, type);
+        Type type = new TypeToken<Result<List<Object>>>(){}.getType();
+        return (Result<List<Object>>) this.APICall("Core/GetWebauthnCredentialSummaries", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
+     * Name Description Optional
      * @return Object
      */
     public Object GetWebserverMetrics() {
         HashMap<String, Object> args = new HashMap<>();
-        Type type = new TypeToken<Object>() {}.getType();
-        return this.APICall("Core/GetWebserverMetrics", args, type);
+        Type type = new TypeToken<Object>(){}.getType();
+        return (Object) this.APICall("Core/GetWebserverMetrics", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
+     * Name Description Optional
      * @return Void
      */
     public Void Kill() {
         HashMap<String, Object> args = new HashMap<>();
-        Type type = new TypeToken<Void>() {}.getType();
+        Type type = new TypeToken<Void>(){}.getType();
         return (Void) this.APICall("Core/Kill", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param username False
-     * @param password False
-     * @param token False
-     * @param rememberMe False
+     * Name Description Optional
+     * @param username  False
+     * @param password  False
+     * @param token  False
+     * @param rememberMe  False
      * @return LoginResult
      */
     public LoginResult Login(String username, String password, String token, Boolean rememberMe) {
@@ -848,172 +893,184 @@ public class Core extends AMPAPI {
         args.put("password", password);
         args.put("token", token);
         args.put("rememberMe", rememberMe);
-        Type type = new TypeToken<LoginResult>() {}.getType();
+        Type type = new TypeToken<LoginResult>(){}.getType();
         return (LoginResult) this.APICall("Core/Login", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
+     * Name Description Optional
      * @return Void
      */
     public Void Logout() {
         HashMap<String, Object> args = new HashMap<>();
-        Type type = new TypeToken<Void>() {}.getType();
+        Type type = new TypeToken<Void>(){}.getType();
         return (Void) this.APICall("Core/Logout", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param Node False
+     * Name Description Optional
+     * @param Node  False
      * @return ActionResult
      */
     public ActionResult RefreshSettingValueList(String Node) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("Node", Node);
-        Type type = new TypeToken<ActionResult>() {}.getType();
+        Type type = new TypeToken<ActionResult>(){}.getType();
         return (ActionResult) this.APICall("Core/RefreshSettingValueList", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
+     * Name Description Optional
      * @return Void
      */
     public Void RefreshSettingsSourceCache() {
         HashMap<String, Object> args = new HashMap<>();
-        Type type = new TypeToken<Void>() {}.getType();
+        Type type = new TypeToken<Void>(){}.getType();
         return (Void) this.APICall("Core/RefreshSettingsSourceCache", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param RoleId False
-     * @param NewName False
+     * Name Description Optional
+     * @param RoleId  False
+     * @param NewName  False
      * @return Task<ActionResult>
      */
     public Task<ActionResult> RenameRole(UUID RoleId, String NewName) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("RoleId", RoleId);
         args.put("NewName", NewName);
-        Type type = new TypeToken<Task<ActionResult>>() {}.getType();
+        Type type = new TypeToken<Task<ActionResult>>(){}.getType();
         return (Task<ActionResult>) this.APICall("Core/RenameRole", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param Username False
-     * @param NewPassword False
+     * Name Description Optional
+     * @param Username  False
+     * @param NewPassword  False
      * @return Task<ActionResult>
      */
     public Task<ActionResult> ResetUserPassword(String Username, String NewPassword) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("Username", Username);
         args.put("NewPassword", NewPassword);
-        Type type = new TypeToken<Task<ActionResult>>() {}.getType();
+        Type type = new TypeToken<Task<ActionResult>>(){}.getType();
         return (Task<ActionResult>) this.APICall("Core/ResetUserPassword", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
+     * Name Description Optional
      * @return ActionResult
      */
     public ActionResult Restart() {
         HashMap<String, Object> args = new HashMap<>();
-        Type type = new TypeToken<ActionResult>() {}.getType();
+        Type type = new TypeToken<ActionResult>(){}.getType();
         return (ActionResult) this.APICall("Core/Restart", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
+     * Name Description Optional
      * @return Void
      */
     public Void RestartAMP() {
         HashMap<String, Object> args = new HashMap<>();
-        Type type = new TypeToken<Void>() {}.getType();
+        Type type = new TypeToken<Void>(){}.getType();
         return (Void) this.APICall("Core/RestartAMP", args, type);
     }
 
     /**
-     * Allows the service to be re-started after previously being suspended. Name Description
-     * Optional
+     * 
+     * Allows the service to be re-started after previously being suspended.
      *
+     * Name Description Optional
      * @return Void
      */
     public Void Resume() {
         HashMap<String, Object> args = new HashMap<>();
-        Type type = new TypeToken<Void>() {}.getType();
+        Type type = new TypeToken<Void>(){}.getType();
         return (Void) this.APICall("Core/Resume", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param ID False
+     * Name Description Optional
+     * @param ID  False
      * @return ActionResult
      */
     public ActionResult RevokeWebauthnCredential(Integer ID) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("ID", ID);
-        Type type = new TypeToken<ActionResult>() {}.getType();
+        Type type = new TypeToken<ActionResult>(){}.getType();
         return (ActionResult) this.APICall("Core/RevokeWebauthnCredential", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param triggerId False
+     * Name Description Optional
+     * @param triggerId  False
      * @return ActionResult
      */
     public ActionResult RunEventTriggerImmediately(UUID triggerId) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("triggerId", triggerId);
-        Type type = new TypeToken<ActionResult>() {}.getType();
+        Type type = new TypeToken<ActionResult>(){}.getType();
         return (ActionResult) this.APICall("Core/RunEventTriggerImmediately", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param message False
+     * Name Description Optional
+     * @param message  False
      * @return Void
      */
     public Void SendConsoleMessage(String message) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("message", message);
-        Type type = new TypeToken<Void>() {}.getType();
+        Type type = new TypeToken<Void>(){}.getType();
         return (Void) this.APICall("Core/SendConsoleMessage", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param RoleId False
-     * @param PermissionNode False
-     * @param Enabled False
+     * Name Description Optional
+     * @param RoleId  False
+     * @param PermissionNode  False
+     * @param Enabled  False
      * @return Task<ActionResult>
      */
-    public Task<ActionResult> SetAMPRolePermission(
-            UUID RoleId, String PermissionNode, Boolean Enabled) {
+    public Task<ActionResult> SetAMPRolePermission(UUID RoleId, String PermissionNode, Boolean Enabled) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("RoleId", RoleId);
         args.put("PermissionNode", PermissionNode);
         args.put("Enabled", Enabled);
-        Type type = new TypeToken<Task<ActionResult>>() {}.getType();
+        Type type = new TypeToken<Task<ActionResult>>(){}.getType();
         return (Task<ActionResult>) this.APICall("Core/SetAMPRolePermission", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param UserId False
-     * @param RoleId False
-     * @param IsMember False
+     * Name Description Optional
+     * @param UserId  False
+     * @param RoleId  False
+     * @param IsMember  False
      * @return Task<ActionResult>
      */
     public Task<ActionResult> SetAMPUserRoleMembership(UUID UserId, UUID RoleId, Boolean IsMember) {
@@ -1021,153 +1078,158 @@ public class Core extends AMPAPI {
         args.put("UserId", UserId);
         args.put("RoleId", RoleId);
         args.put("IsMember", IsMember);
-        Type type = new TypeToken<Task<ActionResult>>() {}.getType();
+        Type type = new TypeToken<Task<ActionResult>>(){}.getType();
         return (Task<ActionResult>) this.APICall("Core/SetAMPUserRoleMembership", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param node False
-     * @param value False
+     * Name Description Optional
+     * @param node  False
+     * @param value  False
      * @return ActionResult
      */
     public ActionResult SetConfig(String node, String value) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("node", node);
         args.put("value", value);
-        Type type = new TypeToken<ActionResult>() {}.getType();
+        Type type = new TypeToken<ActionResult>(){}.getType();
         return (ActionResult) this.APICall("Core/SetConfig", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param data False
+     * Name Description Optional
+     * @param data  False
      * @return Boolean
      */
     public Boolean SetConfigs(Map<String, String> data) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("data", data);
-        Type type = new TypeToken<Boolean>() {}.getType();
+        Type type = new TypeToken<Boolean>(){}.getType();
         return (Boolean) this.APICall("Core/SetConfigs", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param Id False
-     * @param Enabled False
+     * Name Description Optional
+     * @param Id  False
+     * @param Enabled  False
      * @return ActionResult
      */
     public ActionResult SetTriggerEnabled(UUID Id, Boolean Enabled) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("Id", Id);
         args.put("Enabled", Enabled);
-        Type type = new TypeToken<ActionResult>() {}.getType();
+        Type type = new TypeToken<ActionResult>(){}.getType();
         return (ActionResult) this.APICall("Core/SetTriggerEnabled", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
+     * Name Description Optional
      * @return ActionResult
      */
     public ActionResult Sleep() {
         HashMap<String, Object> args = new HashMap<>();
-        Type type = new TypeToken<ActionResult>() {}.getType();
+        Type type = new TypeToken<ActionResult>(){}.getType();
         return (ActionResult) this.APICall("Core/Sleep", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
+     * Name Description Optional
      * @return ActionResult
      */
     public ActionResult Start() {
         HashMap<String, Object> args = new HashMap<>();
-        Type type = new TypeToken<ActionResult>() {}.getType();
+        Type type = new TypeToken<ActionResult>(){}.getType();
         return (ActionResult) this.APICall("Core/Start", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
+     * Name Description Optional
      * @return Void
      */
     public Void Stop() {
         HashMap<String, Object> args = new HashMap<>();
-        Type type = new TypeToken<Void>() {}.getType();
+        Type type = new TypeToken<Void>(){}.getType();
         return (Void) this.APICall("Core/Stop", args, type);
     }
 
     /**
+     * 
      * Prevents the current instance from being started, and stops it if it's currently running.
-     * Name Description Optional
      *
+     * Name Description Optional
      * @return Void
      */
     public Void Suspend() {
         HashMap<String, Object> args = new HashMap<>();
-        Type type = new TypeToken<Void>() {}.getType();
+        Type type = new TypeToken<Void>(){}.getType();
         return (Void) this.APICall("Core/Suspend", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
+     * Name Description Optional
      * @return Void
      */
     public Void UpdateAMPInstance() {
         HashMap<String, Object> args = new HashMap<>();
-        Type type = new TypeToken<Void>() {}.getType();
+        Type type = new TypeToken<Void>(){}.getType();
         return (Void) this.APICall("Core/UpdateAMPInstance", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param EmailAddress False
-     * @param TwoFactorPIN False
+     * Name Description Optional
+     * @param EmailAddress  False
+     * @param TwoFactorPIN  False
      * @return Task<ActionResult>
      */
     public Task<ActionResult> UpdateAccountInfo(String EmailAddress, String TwoFactorPIN) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("EmailAddress", EmailAddress);
         args.put("TwoFactorPIN", TwoFactorPIN);
-        Type type = new TypeToken<Task<ActionResult>>() {}.getType();
+        Type type = new TypeToken<Task<ActionResult>>(){}.getType();
         return (Task<ActionResult>) this.APICall("Core/UpdateAccountInfo", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
+     * Name Description Optional
      * @return ActionResult
      */
     public ActionResult UpdateApplication() {
         HashMap<String, Object> args = new HashMap<>();
-        Type type = new TypeToken<ActionResult>() {}.getType();
+        Type type = new TypeToken<ActionResult>(){}.getType();
         return (ActionResult) this.APICall("Core/UpdateApplication", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param Username False
-     * @param Disabled False
-     * @param PasswordExpires False
-     * @param CannotChangePassword False
-     * @param MustChangePassword False
-     * @param EmailAddress True
+     * Name Description Optional
+     * @param Username  False
+     * @param Disabled  False
+     * @param PasswordExpires  False
+     * @param CannotChangePassword  False
+     * @param MustChangePassword  False
+     * @param EmailAddress  True
      * @return Task<ActionResult>
      */
-    public Task<ActionResult> UpdateUserInfo(
-            String Username,
-            Boolean Disabled,
-            Boolean PasswordExpires,
-            Boolean CannotChangePassword,
-            Boolean MustChangePassword,
-            String EmailAddress) {
+    public Task<ActionResult> UpdateUserInfo(String Username, Boolean Disabled, Boolean PasswordExpires, Boolean CannotChangePassword, Boolean MustChangePassword, String EmailAddress) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("Username", Username);
         args.put("Disabled", Disabled);
@@ -1175,36 +1237,38 @@ public class Core extends AMPAPI {
         args.put("CannotChangePassword", CannotChangePassword);
         args.put("MustChangePassword", MustChangePassword);
         args.put("EmailAddress", EmailAddress);
-        Type type = new TypeToken<Task<ActionResult>>() {}.getType();
+        Type type = new TypeToken<Task<ActionResult>>(){}.getType();
         return (Task<ActionResult>) this.APICall("Core/UpdateUserInfo", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
+     * Name Description Optional
      * @return Void
      */
     public Void UpgradeAMP() {
         HashMap<String, Object> args = new HashMap<>();
-        Type type = new TypeToken<Void>() {}.getType();
+        Type type = new TypeToken<Void>(){}.getType();
         return (Void) this.APICall("Core/UpgradeAMP", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param attestationObject False
-     * @param clientDataJSON False
-     * @param description True
+     * Name Description Optional
+     * @param attestationObject  False
+     * @param clientDataJSON  False
+     * @param description  True
      * @return ActionResult
      */
-    public ActionResult WebauthnRegister(
-            String attestationObject, String clientDataJSON, String description) {
+    public ActionResult WebauthnRegister(String attestationObject, String clientDataJSON, String description) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("attestationObject", attestationObject);
         args.put("clientDataJSON", clientDataJSON);
         args.put("description", description);
-        Type type = new TypeToken<ActionResult>() {}.getType();
+        Type type = new TypeToken<ActionResult>(){}.getType();
         return (ActionResult) this.APICall("Core/WebauthnRegister", args, type);
     }
+
 }

--- a/src/main/java/dev/neuralnexus/ampapi/apimodules/EmailSenderPlugin.java
+++ b/src/main/java/dev/neuralnexus/ampapi/apimodules/EmailSenderPlugin.java
@@ -6,7 +6,11 @@ import dev.neuralnexus.ampapi.AMPAPI;
 import dev.neuralnexus.ampapi.types.*;
 
 import java.lang.reflect.Type;
+import java.net.URL;
 import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 
 public class EmailSenderPlugin extends AMPAPI {
     public EmailSenderPlugin(AMPAPI ampapi) {
@@ -14,13 +18,15 @@ public class EmailSenderPlugin extends AMPAPI {
     }
 
     /**
-     * Name Description Optional
+     * 
      *
+     * Name Description Optional
      * @return Task<ActionResult>
      */
     public Task<ActionResult> TestSMTPSettings() {
         HashMap<String, Object> args = new HashMap<>();
-        Type type = new TypeToken<Task<ActionResult>>() {}.getType();
+        Type type = new TypeToken<Task<ActionResult>>(){}.getType();
         return (Task<ActionResult>) this.APICall("EmailSenderPlugin/TestSMTPSettings", args, type);
     }
+
 }

--- a/src/main/java/dev/neuralnexus/ampapi/apimodules/FileManagerPlugin.java
+++ b/src/main/java/dev/neuralnexus/ampapi/apimodules/FileManagerPlugin.java
@@ -9,6 +9,8 @@ import java.lang.reflect.Type;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 
 public class FileManagerPlugin extends AMPAPI {
     public FileManagerPlugin(AMPAPI ampapi) {
@@ -16,11 +18,12 @@ public class FileManagerPlugin extends AMPAPI {
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param Filename False
-     * @param Data False
-     * @param Delete False
+     * Name Description Optional
+     * @param Filename  False
+     * @param Data  False
+     * @param Delete  False
      * @return Void
      */
     public Void AppendFileChunk(String Filename, String Data, Boolean Delete) {
@@ -28,30 +31,31 @@ public class FileManagerPlugin extends AMPAPI {
         args.put("Filename", Filename);
         args.put("Data", Data);
         args.put("Delete", Delete);
-        Type type = new TypeToken<Void>() {}.getType();
+        Type type = new TypeToken<Void>(){}.getType();
         return (Void) this.APICall("FileManagerPlugin/AppendFileChunk", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param FilePath False
+     * Name Description Optional
+     * @param FilePath  False
      * @return ActionResult<String>
      */
     public ActionResult<String> CalculateFileMD5Sum(String FilePath) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("FilePath", FilePath);
-        Type type = new TypeToken<ActionResult<String>>() {}.getType();
-        return (ActionResult<String>)
-                this.APICall("FileManagerPlugin/CalculateFileMD5Sum", args, type);
+        Type type = new TypeToken<ActionResult<String>>(){}.getType();
+        return (ActionResult<String>) this.APICall("FileManagerPlugin/CalculateFileMD5Sum", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param ModifyPath False
-     * @param AsDirectory False
-     * @param Exclude False
+     * Name Description Optional
+     * @param ModifyPath  False
+     * @param AsDirectory  False
+     * @param Exclude  False
      * @return ActionResult
      */
     public ActionResult ChangeExclusion(String ModifyPath, Boolean AsDirectory, Boolean Exclude) {
@@ -59,125 +63,133 @@ public class FileManagerPlugin extends AMPAPI {
         args.put("ModifyPath", ModifyPath);
         args.put("AsDirectory", AsDirectory);
         args.put("Exclude", Exclude);
-        Type type = new TypeToken<ActionResult>() {}.getType();
+        Type type = new TypeToken<ActionResult>(){}.getType();
         return (ActionResult) this.APICall("FileManagerPlugin/ChangeExclusion", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param Origin False
-     * @param TargetDirectory False
+     * Name Description Optional
+     * @param Origin  False
+     * @param TargetDirectory  False
      * @return ActionResult
      */
     public ActionResult CopyFile(String Origin, String TargetDirectory) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("Origin", Origin);
         args.put("TargetDirectory", TargetDirectory);
-        Type type = new TypeToken<ActionResult>() {}.getType();
+        Type type = new TypeToken<ActionResult>(){}.getType();
         return (ActionResult) this.APICall("FileManagerPlugin/CopyFile", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param PathToArchive False
+     * Name Description Optional
+     * @param PathToArchive  False
      * @return ActionResult
      */
     public ActionResult CreateArchive(String PathToArchive) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("PathToArchive", PathToArchive);
-        Type type = new TypeToken<ActionResult>() {}.getType();
+        Type type = new TypeToken<ActionResult>(){}.getType();
         return (ActionResult) this.APICall("FileManagerPlugin/CreateArchive", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param NewPath False
+     * Name Description Optional
+     * @param NewPath  False
      * @return ActionResult
      */
     public ActionResult CreateDirectory(String NewPath) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("NewPath", NewPath);
-        Type type = new TypeToken<ActionResult>() {}.getType();
+        Type type = new TypeToken<ActionResult>(){}.getType();
         return (ActionResult) this.APICall("FileManagerPlugin/CreateDirectory", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param Source False
-     * @param TargetDirectory False
+     * Name Description Optional
+     * @param Source  False
+     * @param TargetDirectory  False
      * @return ActionResult
      */
     public ActionResult DownloadFileFromURL(URL Source, String TargetDirectory) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("Source", Source);
         args.put("TargetDirectory", TargetDirectory);
-        Type type = new TypeToken<ActionResult>() {}.getType();
+        Type type = new TypeToken<ActionResult>(){}.getType();
         return (ActionResult) this.APICall("FileManagerPlugin/DownloadFileFromURL", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
+     * Name Description Optional
      * @return Void
      */
     public Void Dummy() {
         HashMap<String, Object> args = new HashMap<>();
-        Type type = new TypeToken<Void>() {}.getType();
+        Type type = new TypeToken<Void>(){}.getType();
         return (Void) this.APICall("FileManagerPlugin/Dummy", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param TrashDirectoryName False
+     * Name Description Optional
+     * @param TrashDirectoryName  False
      * @return ActionResult
      */
     public ActionResult EmptyTrash(String TrashDirectoryName) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("TrashDirectoryName", TrashDirectoryName);
-        Type type = new TypeToken<ActionResult>() {}.getType();
+        Type type = new TypeToken<ActionResult>(){}.getType();
         return (ActionResult) this.APICall("FileManagerPlugin/EmptyTrash", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param ArchivePath False
-     * @param DestinationPath True
+     * Name Description Optional
+     * @param ArchivePath  False
+     * @param DestinationPath  True
      * @return ActionResult
      */
     public ActionResult ExtractArchive(String ArchivePath, String DestinationPath) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("ArchivePath", ArchivePath);
         args.put("DestinationPath", DestinationPath);
-        Type type = new TypeToken<ActionResult>() {}.getType();
+        Type type = new TypeToken<ActionResult>(){}.getType();
         return (ActionResult) this.APICall("FileManagerPlugin/ExtractArchive", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param Dir False
+     * Name Description Optional
+     * @param Dir  False
      * @return Result<List<FileDirectory>>
      */
     public Result<List<FileDirectory>> GetDirectoryListing(String Dir) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("Dir", Dir);
-        Type type = new TypeToken<Result<List<FileDirectory>>>() {}.getType();
-        return (Result<List<FileDirectory>>)
-                this.APICall("FileManagerPlugin/GetDirectoryListing", args, type);
+        Type type = new TypeToken<Result<List<FileDirectory>>>(){}.getType();
+        return (Result<List<FileDirectory>>) this.APICall("FileManagerPlugin/GetDirectoryListing", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param Filename False
-     * @param Position False
-     * @param Length False
+     * Name Description Optional
+     * @param Filename  False
+     * @param Position  False
+     * @param Length  False
      * @return Object
      */
     public Object GetFileChunk(String Filename, Integer Position, Integer Length) {
@@ -185,32 +197,32 @@ public class FileManagerPlugin extends AMPAPI {
         args.put("Filename", Filename);
         args.put("Position", Position);
         args.put("Length", Length);
-        Type type = new TypeToken<Object>() {}.getType();
-        return this.APICall("FileManagerPlugin/GetFileChunk", args, type);
+        Type type = new TypeToken<Object>(){}.getType();
+        return (Object) this.APICall("FileManagerPlugin/GetFileChunk", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param Filename False
-     * @param Offset False
-     * @param ChunkSize True
+     * Name Description Optional
+     * @param Filename  False
+     * @param Offset  False
+     * @param ChunkSize  True
      * @return Result<ActionResult<String>>
      */
-    public Result<ActionResult<String>> ReadFileChunk(
-            String Filename, Integer Offset, Integer ChunkSize) {
+    public Result<ActionResult<String>> ReadFileChunk(String Filename, Integer Offset, Integer ChunkSize) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("Filename", Filename);
         args.put("Offset", Offset);
         args.put("ChunkSize", ChunkSize);
-        Type type = new TypeToken<Result<ActionResult<String>>>() {}.getType();
-        return (Result<ActionResult<String>>)
-                this.APICall("FileManagerPlugin/ReadFileChunk", args, type);
+        Type type = new TypeToken<Result<ActionResult<String>>>(){}.getType();
+        return (Result<ActionResult<String>>) this.APICall("FileManagerPlugin/ReadFileChunk", args, type);
     }
 
     /**
-     * The name component of the new directory (not the full path) Name Description Optional
+     * The name component of the new directory (not the full path)
      *
+     * Name Description Optional
      * @param oldDirectory The full path to the old directory False
      * @param NewDirectoryName The name component of the new directory (not the full path) False
      * @return ActionResult
@@ -219,68 +231,72 @@ public class FileManagerPlugin extends AMPAPI {
         HashMap<String, Object> args = new HashMap<>();
         args.put("oldDirectory", oldDirectory);
         args.put("NewDirectoryName", NewDirectoryName);
-        Type type = new TypeToken<ActionResult>() {}.getType();
+        Type type = new TypeToken<ActionResult>(){}.getType();
         return (ActionResult) this.APICall("FileManagerPlugin/RenameDirectory", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param Filename False
-     * @param NewFilename False
+     * Name Description Optional
+     * @param Filename  False
+     * @param NewFilename  False
      * @return ActionResult
      */
     public ActionResult RenameFile(String Filename, String NewFilename) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("Filename", Filename);
         args.put("NewFilename", NewFilename);
-        Type type = new TypeToken<ActionResult>() {}.getType();
+        Type type = new TypeToken<ActionResult>(){}.getType();
         return (ActionResult) this.APICall("FileManagerPlugin/RenameFile", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param DirectoryName False
+     * Name Description Optional
+     * @param DirectoryName  False
      * @return ActionResult
      */
     public ActionResult TrashDirectory(String DirectoryName) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("DirectoryName", DirectoryName);
-        Type type = new TypeToken<ActionResult>() {}.getType();
+        Type type = new TypeToken<ActionResult>(){}.getType();
         return (ActionResult) this.APICall("FileManagerPlugin/TrashDirectory", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param Filename False
+     * Name Description Optional
+     * @param Filename  False
      * @return ActionResult
      */
     public ActionResult TrashFile(String Filename) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("Filename", Filename);
-        Type type = new TypeToken<ActionResult>() {}.getType();
+        Type type = new TypeToken<ActionResult>(){}.getType();
         return (ActionResult) this.APICall("FileManagerPlugin/TrashFile", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param Filename False
-     * @param Data False
-     * @param Offset False
-     * @param FinalChunk False
+     * Name Description Optional
+     * @param Filename  False
+     * @param Data  False
+     * @param Offset  False
+     * @param FinalChunk  False
      * @return ActionResult
      */
-    public ActionResult WriteFileChunk(
-            String Filename, String Data, Integer Offset, Boolean FinalChunk) {
+    public ActionResult WriteFileChunk(String Filename, String Data, Integer Offset, Boolean FinalChunk) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("Filename", Filename);
         args.put("Data", Data);
         args.put("Offset", Offset);
         args.put("FinalChunk", FinalChunk);
-        Type type = new TypeToken<ActionResult>() {}.getType();
+        Type type = new TypeToken<ActionResult>(){}.getType();
         return (ActionResult) this.APICall("FileManagerPlugin/WriteFileChunk", args, type);
     }
+
 }

--- a/src/main/java/dev/neuralnexus/ampapi/apimodules/LocalFileBackupPlugin.java
+++ b/src/main/java/dev/neuralnexus/ampapi/apimodules/LocalFileBackupPlugin.java
@@ -6,8 +6,10 @@ import dev.neuralnexus.ampapi.AMPAPI;
 import dev.neuralnexus.ampapi.types.*;
 
 import java.lang.reflect.Type;
+import java.net.URL;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 public class LocalFileBackupPlugin extends AMPAPI {
@@ -16,92 +18,98 @@ public class LocalFileBackupPlugin extends AMPAPI {
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param BackupId False
+     * Name Description Optional
+     * @param BackupId  False
      * @return Task<ActionResult>
      */
     public Task<ActionResult> DeleteFromS3(UUID BackupId) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("BackupId", BackupId);
-        Type type = new TypeToken<Task<ActionResult>>() {}.getType();
+        Type type = new TypeToken<Task<ActionResult>>(){}.getType();
         return (Task<ActionResult>) this.APICall("LocalFileBackupPlugin/DeleteFromS3", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param BackupId False
+     * Name Description Optional
+     * @param BackupId  False
      * @return Void
      */
     public Void DeleteLocalBackup(UUID BackupId) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("BackupId", BackupId);
-        Type type = new TypeToken<Void>() {}.getType();
+        Type type = new TypeToken<Void>(){}.getType();
         return (Void) this.APICall("LocalFileBackupPlugin/DeleteLocalBackup", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param BackupId False
+     * Name Description Optional
+     * @param BackupId  False
      * @return Result<RunningTask>
      */
     public Result<RunningTask> DownloadFromS3(UUID BackupId) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("BackupId", BackupId);
-        Type type = new TypeToken<Result<RunningTask>>() {}.getType();
-        return (Result<RunningTask>)
-                this.APICall("LocalFileBackupPlugin/DownloadFromS3", args, type);
+        Type type = new TypeToken<Result<RunningTask>>(){}.getType();
+        return (Result<RunningTask>) this.APICall("LocalFileBackupPlugin/DownloadFromS3", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
+     * Name Description Optional
      * @return Result<List<Object>>
      */
     public Result<List<Object>> GetBackups() {
         HashMap<String, Object> args = new HashMap<>();
-        Type type = new TypeToken<Result<List<Object>>>() {}.getType();
+        Type type = new TypeToken<Result<List<Object>>>(){}.getType();
         return (Result<List<Object>>) this.APICall("LocalFileBackupPlugin/GetBackups", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param BackupId False
-     * @param DeleteExistingData True
+     * Name Description Optional
+     * @param BackupId  False
+     * @param DeleteExistingData  True
      * @return ActionResult
      */
     public ActionResult RestoreBackup(UUID BackupId, Boolean DeleteExistingData) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("BackupId", BackupId);
         args.put("DeleteExistingData", DeleteExistingData);
-        Type type = new TypeToken<ActionResult>() {}.getType();
+        Type type = new TypeToken<ActionResult>(){}.getType();
         return (ActionResult) this.APICall("LocalFileBackupPlugin/RestoreBackup", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param BackupId False
-     * @param Sticky False
+     * Name Description Optional
+     * @param BackupId  False
+     * @param Sticky  False
      * @return Void
      */
     public Void SetBackupSticky(UUID BackupId, Boolean Sticky) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("BackupId", BackupId);
         args.put("Sticky", Sticky);
-        Type type = new TypeToken<Void>() {}.getType();
+        Type type = new TypeToken<Void>(){}.getType();
         return (Void) this.APICall("LocalFileBackupPlugin/SetBackupSticky", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param Title False
-     * @param Description False
-     * @param Sticky False
+     * Name Description Optional
+     * @param Title  False
+     * @param Description  False
+     * @param Sticky  False
      * @return ActionResult
      */
     public ActionResult TakeBackup(String Title, String Description, Boolean Sticky) {
@@ -109,20 +117,22 @@ public class LocalFileBackupPlugin extends AMPAPI {
         args.put("Title", Title);
         args.put("Description", Description);
         args.put("Sticky", Sticky);
-        Type type = new TypeToken<ActionResult>() {}.getType();
+        Type type = new TypeToken<ActionResult>(){}.getType();
         return (ActionResult) this.APICall("LocalFileBackupPlugin/TakeBackup", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param BackupId False
+     * Name Description Optional
+     * @param BackupId  False
      * @return Result<RunningTask>
      */
     public Result<RunningTask> UploadToS3(UUID BackupId) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("BackupId", BackupId);
-        Type type = new TypeToken<Result<RunningTask>>() {}.getType();
+        Type type = new TypeToken<Result<RunningTask>>(){}.getType();
         return (Result<RunningTask>) this.APICall("LocalFileBackupPlugin/UploadToS3", args, type);
     }
+
 }

--- a/src/main/java/dev/neuralnexus/ampapi/apimodules/MinecraftModule.java
+++ b/src/main/java/dev/neuralnexus/ampapi/apimodules/MinecraftModule.java
@@ -6,9 +6,11 @@ import dev.neuralnexus.ampapi.AMPAPI;
 import dev.neuralnexus.ampapi.types.*;
 
 import java.lang.reflect.Type;
+import java.net.URL;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 public class MinecraftModule extends AMPAPI {
     public MinecraftModule(AMPAPI ampapi) {
@@ -16,155 +18,162 @@ public class MinecraftModule extends AMPAPI {
     }
 
     /**
-     * Name Description Optional
+     * 
      *
+     * Name Description Optional
      * @return Boolean
      */
     public Boolean AcceptEULA() {
         HashMap<String, Object> args = new HashMap<>();
-        Type type = new TypeToken<Boolean>() {}.getType();
+        Type type = new TypeToken<Boolean>(){}.getType();
         return (Boolean) this.APICall("MinecraftModule/AcceptEULA", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param UserOrUUID False
+     * Name Description Optional
+     * @param UserOrUUID  False
      * @return Task<ActionResult>
      */
     public Task<ActionResult> AddOPEntry(String UserOrUUID) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("UserOrUUID", UserOrUUID);
-        Type type = new TypeToken<Task<ActionResult>>() {}.getType();
+        Type type = new TypeToken<Task<ActionResult>>(){}.getType();
         return (Task<ActionResult>) this.APICall("MinecraftModule/AddOPEntry", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param UserOrUUID False
+     * Name Description Optional
+     * @param UserOrUUID  False
      * @return Task<ActionResult>
      */
     public Task<ActionResult> AddToWhitelist(String UserOrUUID) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("UserOrUUID", UserOrUUID);
-        Type type = new TypeToken<Task<ActionResult>>() {}.getType();
+        Type type = new TypeToken<Task<ActionResult>>(){}.getType();
         return (Task<ActionResult>) this.APICall("MinecraftModule/AddToWhitelist", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param ID False
+     * Name Description Optional
+     * @param ID  False
      * @return Void
      */
     public Void BanUserByID(String ID) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("ID", ID);
-        Type type = new TypeToken<Void>() {}.getType();
+        Type type = new TypeToken<Void>(){}.getType();
         return (Void) this.APICall("MinecraftModule/BanUserByID", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
+     * Name Description Optional
      * @return Map<String, Object>
      */
     public Map<String, Object> BukGetCategories() {
         HashMap<String, Object> args = new HashMap<>();
-        Type type = new TypeToken<Map<String, Object>>() {}.getType();
+        Type type = new TypeToken<Map<String, Object>>(){}.getType();
         return (Map<String, Object>) this.APICall("MinecraftModule/BukGetCategories", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param pluginId False
+     * Name Description Optional
+     * @param pluginId  False
      * @return Task<RunningTask>
      */
     public Task<RunningTask> BukGetInstallUpdatePlugin(Integer pluginId) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("pluginId", pluginId);
-        Type type = new TypeToken<Task<RunningTask>>() {}.getType();
-        return (Task<RunningTask>)
-                this.APICall("MinecraftModule/BukGetInstallUpdatePlugin", args, type);
+        Type type = new TypeToken<Task<RunningTask>>(){}.getType();
+        return (Task<RunningTask>) this.APICall("MinecraftModule/BukGetInstallUpdatePlugin", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
+     * Name Description Optional
      * @return Map<String, Object>
      */
     public Map<String, Object> BukGetInstalledPlugins() {
         HashMap<String, Object> args = new HashMap<>();
-        Type type = new TypeToken<Map<String, Object>>() {}.getType();
-        return (Map<String, Object>)
-                this.APICall("MinecraftModule/BukGetInstalledPlugins", args, type);
+        Type type = new TypeToken<Map<String, Object>>(){}.getType();
+        return (Map<String, Object>) this.APICall("MinecraftModule/BukGetInstalledPlugins", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param PluginId False
+     * Name Description Optional
+     * @param PluginId  False
      * @return Map<String, Object>
      */
     public Map<String, Object> BukGetPluginInfo(Integer PluginId) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("PluginId", PluginId);
-        Type type = new TypeToken<Map<String, Object>>() {}.getType();
+        Type type = new TypeToken<Map<String, Object>>(){}.getType();
         return (Map<String, Object>) this.APICall("MinecraftModule/BukGetPluginInfo", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param CategoryId False
-     * @param PageNumber False
-     * @param PageSize False
+     * Name Description Optional
+     * @param CategoryId  False
+     * @param PageNumber  False
+     * @param PageSize  False
      * @return Map<String, Object>
      */
-    public Map<String, Object> BukGetPluginsForCategory(
-            String CategoryId, Integer PageNumber, Integer PageSize) {
+    public Map<String, Object> BukGetPluginsForCategory(String CategoryId, Integer PageNumber, Integer PageSize) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("CategoryId", CategoryId);
         args.put("PageNumber", PageNumber);
         args.put("PageSize", PageSize);
-        Type type = new TypeToken<Map<String, Object>>() {}.getType();
-        return (Map<String, Object>)
-                this.APICall("MinecraftModule/BukGetPluginsForCategory", args, type);
+        Type type = new TypeToken<Map<String, Object>>(){}.getType();
+        return (Map<String, Object>) this.APICall("MinecraftModule/BukGetPluginsForCategory", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
+     * Name Description Optional
      * @return Map<String, Object>
      */
     public Map<String, Object> BukGetPopularPlugins() {
         HashMap<String, Object> args = new HashMap<>();
-        Type type = new TypeToken<Map<String, Object>>() {}.getType();
-        return (Map<String, Object>)
-                this.APICall("MinecraftModule/BukGetPopularPlugins", args, type);
+        Type type = new TypeToken<Map<String, Object>>(){}.getType();
+        return (Map<String, Object>) this.APICall("MinecraftModule/BukGetPopularPlugins", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param PluginId False
+     * Name Description Optional
+     * @param PluginId  False
      * @return Void
      */
     public Void BukGetRemovePlugin(Integer PluginId) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("PluginId", PluginId);
-        Type type = new TypeToken<Void>() {}.getType();
+        Type type = new TypeToken<Void>(){}.getType();
         return (Void) this.APICall("MinecraftModule/BukGetRemovePlugin", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param Query False
-     * @param PageNumber False
-     * @param PageSize False
+     * Name Description Optional
+     * @param Query  False
+     * @param PageNumber  False
+     * @param PageSize  False
      * @return Map<String, Object>
      */
     public Map<String, Object> BukGetSearch(String Query, Integer PageNumber, Integer PageSize) {
@@ -172,144 +181,154 @@ public class MinecraftModule extends AMPAPI {
         args.put("Query", Query);
         args.put("PageNumber", PageNumber);
         args.put("PageSize", PageSize);
-        Type type = new TypeToken<Map<String, Object>>() {}.getType();
+        Type type = new TypeToken<Map<String, Object>>(){}.getType();
         return (Map<String, Object>) this.APICall("MinecraftModule/BukGetSearch", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param ID False
+     * Name Description Optional
+     * @param ID  False
      * @return Void
      */
     public Void ClearInventoryByID(String ID) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("ID", ID);
-        Type type = new TypeToken<Void>() {}.getType();
+        Type type = new TypeToken<Void>(){}.getType();
         return (Void) this.APICall("MinecraftModule/ClearInventoryByID", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
+     * Name Description Optional
      * @return String
      */
     public String GetFailureReason() {
         HashMap<String, Object> args = new HashMap<>();
-        Type type = new TypeToken<String>() {}.getType();
+        Type type = new TypeToken<String>(){}.getType();
         return (String) this.APICall("MinecraftModule/GetFailureReason", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param id False
+     * Name Description Optional
+     * @param id  False
      * @return String
      */
     public String GetHeadByUUID(String id) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("id", id);
-        Type type = new TypeToken<String>() {}.getType();
+        Type type = new TypeToken<String>(){}.getType();
         return (String) this.APICall("MinecraftModule/GetHeadByUUID", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
+     * Name Description Optional
      * @return Map<String, Object>
      */
     public Map<String, Object> GetOPWhitelist() {
         HashMap<String, Object> args = new HashMap<>();
-        Type type = new TypeToken<Map<String, Object>>() {}.getType();
+        Type type = new TypeToken<Map<String, Object>>(){}.getType();
         return (Map<String, Object>) this.APICall("MinecraftModule/GetOPWhitelist", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
+     * Name Description Optional
      * @return Result<List<Map<String, Object>>>
      */
     public Result<List<Map<String, Object>>> GetWhitelist() {
         HashMap<String, Object> args = new HashMap<>();
-        Type type = new TypeToken<Result<List<Map<String, Object>>>>() {}.getType();
-        return (Result<List<Map<String, Object>>>)
-                this.APICall("MinecraftModule/GetWhitelist", args, type);
+        Type type = new TypeToken<Result<List<Map<String, Object>>>>(){}.getType();
+        return (Result<List<Map<String, Object>>>) this.APICall("MinecraftModule/GetWhitelist", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param ID False
+     * Name Description Optional
+     * @param ID  False
      * @return Void
      */
     public Void KickUserByID(String ID) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("ID", ID);
-        Type type = new TypeToken<Void>() {}.getType();
+        Type type = new TypeToken<Void>(){}.getType();
         return (Void) this.APICall("MinecraftModule/KickUserByID", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param ID False
+     * Name Description Optional
+     * @param ID  False
      * @return Void
      */
     public Void KillByID(String ID) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("ID", ID);
-        Type type = new TypeToken<Void>() {}.getType();
+        Type type = new TypeToken<Void>(){}.getType();
         return (Void) this.APICall("MinecraftModule/KillByID", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
+     * Name Description Optional
      * @return Result<List<Map<String, Object>>>
      */
     public Result<List<Map<String, Object>>> LoadOPList() {
         HashMap<String, Object> args = new HashMap<>();
-        Type type = new TypeToken<Result<List<Map<String, Object>>>>() {}.getType();
-        return (Result<List<Map<String, Object>>>)
-                this.APICall("MinecraftModule/LoadOPList", args, type);
+        Type type = new TypeToken<Result<List<Map<String, Object>>>>(){}.getType();
+        return (Result<List<Map<String, Object>>>) this.APICall("MinecraftModule/LoadOPList", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param UserOrUUID False
+     * Name Description Optional
+     * @param UserOrUUID  False
      * @return Void
      */
     public Void RemoveOPEntry(String UserOrUUID) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("UserOrUUID", UserOrUUID);
-        Type type = new TypeToken<Void>() {}.getType();
+        Type type = new TypeToken<Void>(){}.getType();
         return (Void) this.APICall("MinecraftModule/RemoveOPEntry", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param UserOrUUID False
+     * Name Description Optional
+     * @param UserOrUUID  False
      * @return Void
      */
     public Void RemoveWhitelistEntry(String UserOrUUID) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("UserOrUUID", UserOrUUID);
-        Type type = new TypeToken<Void>() {}.getType();
+        Type type = new TypeToken<Void>(){}.getType();
         return (Void) this.APICall("MinecraftModule/RemoveWhitelistEntry", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param ID False
+     * Name Description Optional
+     * @param ID  False
      * @return Void
      */
     public Void SmiteByID(String ID) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("ID", ID);
-        Type type = new TypeToken<Void>() {}.getType();
+        Type type = new TypeToken<Void>(){}.getType();
         return (Void) this.APICall("MinecraftModule/SmiteByID", args, type);
     }
+
 }

--- a/src/main/java/dev/neuralnexus/ampapi/apimodules/RCONPlugin.java
+++ b/src/main/java/dev/neuralnexus/ampapi/apimodules/RCONPlugin.java
@@ -6,7 +6,11 @@ import dev.neuralnexus.ampapi.AMPAPI;
 import dev.neuralnexus.ampapi.types.*;
 
 import java.lang.reflect.Type;
+import java.net.URL;
 import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 
 public class RCONPlugin extends AMPAPI {
     public RCONPlugin(AMPAPI ampapi) {
@@ -14,13 +18,15 @@ public class RCONPlugin extends AMPAPI {
     }
 
     /**
-     * Name Description Optional
+     * 
      *
+     * Name Description Optional
      * @return Void
      */
     public Void Dummy() {
         HashMap<String, Object> args = new HashMap<>();
-        Type type = new TypeToken<Void>() {}.getType();
+        Type type = new TypeToken<Void>(){}.getType();
         return (Void) this.APICall("RCONPlugin/Dummy", args, type);
     }
+
 }

--- a/src/main/java/dev/neuralnexus/ampapi/apimodules/steamcmdplugin.java
+++ b/src/main/java/dev/neuralnexus/ampapi/apimodules/steamcmdplugin.java
@@ -6,7 +6,11 @@ import dev.neuralnexus.ampapi.AMPAPI;
 import dev.neuralnexus.ampapi.types.*;
 
 import java.lang.reflect.Type;
+import java.net.URL;
 import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 
 public class steamcmdplugin extends AMPAPI {
     public steamcmdplugin(AMPAPI ampapi) {
@@ -14,41 +18,45 @@ public class steamcmdplugin extends AMPAPI {
     }
 
     /**
-     * Name Description Optional
+     * 
      *
+     * Name Description Optional
      * @return Void
      */
     public Void CancelSteamGuard() {
         HashMap<String, Object> args = new HashMap<>();
-        Type type = new TypeToken<Void>() {}.getType();
+        Type type = new TypeToken<Void>(){}.getType();
         return (Void) this.APICall("steamcmdplugin/CancelSteamGuard", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param code False
+     * Name Description Optional
+     * @param code  False
      * @return Void
      */
     public Void SteamGuardCode(String code) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("code", code);
-        Type type = new TypeToken<Void>() {}.getType();
+        Type type = new TypeToken<Void>(){}.getType();
         return (Void) this.APICall("steamcmdplugin/SteamGuardCode", args, type);
     }
 
     /**
-     * Name Description Optional
+     * 
      *
-     * @param username False
-     * @param password False
+     * Name Description Optional
+     * @param username  False
+     * @param password  False
      * @return Void
      */
     public Void SteamUsernamePassword(String username, String password) {
         HashMap<String, Object> args = new HashMap<>();
         args.put("username", username);
         args.put("password", password);
-        Type type = new TypeToken<Void>() {}.getType();
+        Type type = new TypeToken<Void>(){}.getType();
         return (Void) this.APICall("steamcmdplugin/SteamUsernamePassword", args, type);
     }
+
 }


### PR DESCRIPTION
Updated Methods in AMP v2.4.6.8:

- `ADSModule.RefreshRemoteConfigStores` has a new parameter, `force: Boolean`
- `ADSModule.UpdateInstanceInfo` now returns `ActionResult` rather than `Task<ActionResult>`

```diff
- ADSModule.RefreshRemoteConfigStores() -> Void
+ ADSModule.RefreshRemoteConfigStores(force: Boolean) -> Void

- ADSModule.UpdateInstanceInfo(InstanceId: String, FriendlyName: String, Description: String, StartOnBoot: Boolean, Suspended: Boolean, ExcludeFromFirewall: Boolean, RunInContainer: Boolean, ContainerMemory: Int32, MemoryPolicy: ContainerMemoryPolicy, ContainerMaxCPU: Single, ContainerImage: String) -> Task<ActionResult>
+ ADSModule.UpdateInstanceInfo(InstanceId: String, FriendlyName: String, Description: String, StartOnBoot: Boolean, Suspended: Boolean, ExcludeFromFirewall: Boolean, RunInContainer: Boolean, ContainerMemory: Int32, MemoryPolicy: ContainerMemoryPolicy, ContainerMaxCPU: Single, ContainerImage: String) -> ActionResult
```